### PR TITLE
Improving parsing for GeoLocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ---
 
+[![NuGet](http://img.shields.io/nuget/v/Redis.OM.svg?style=flat-square)](https://www.nuget.org/packages/Redis.OM/)
 [![License][license-image]][license-url]
 [![Build Status][ci-svg]][ci-url]
 
@@ -81,11 +82,11 @@ docker run -p 6379:6379 redislabs/redismod:preview
 With Redis OM, you can model your data and declare indexes with minimal code. For example, here's how we might model a customer object:
 
 ```csharp
-[Document(StorageType = StorageType.Json)]
+[Document]
 public class Customer
 {
-   [Indexed] public string FirstName { get; set; }
-   [Indexed] public string LastName { get; set; }
+   [Indexed(Sortable = true)] public string FirstName { get; set; }
+   [Indexed(Sortable = true)] public string LastName { get; set; }
    [Indexed] public string Email { get; set; }
    [Indexed(Sortable = true)] public int Age { get; set; }
 }

--- a/src/Redis.OM/GeoLoc.cs
+++ b/src/Redis.OM/GeoLoc.cs
@@ -5,7 +5,7 @@ namespace Redis.OM.Modeling
     /// <summary>
     /// A structure representing a point on the globe by it's longitude and latitude.
     /// </summary>
-    public readonly struct GeoLoc
+    public struct GeoLoc
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GeoLoc"/> struct.
@@ -19,14 +19,14 @@ namespace Redis.OM.Modeling
         }
 
         /// <summary>
-        /// Gets the longitude.
+        /// Gets or sets the longitude.
         /// </summary>
-        public double Longitude { get; }
+        public double Longitude { get; set; }
 
         /// <summary>
-        /// Gets the latitude.
+        /// Gets or sets the latitude.
         /// </summary>
-        public double Latitude { get; }
+        public double Latitude { get; set; }
 
         /// <summary>
         /// Parses a Geolocation from a string.

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,7 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.1.0</PackageVersion>
+    <PackageVersion>0.1.1</PackageVersion>
+    <Version>0.1.1</Version>
+    <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>
     <Copyright>Redis Inc</Copyright>

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -253,7 +253,7 @@ namespace Redis.OM
                 {
                     ret += $"\"{propertyName}\":{hash[propertyName]},";
                 }
-                else if (type == typeof(string))
+                else if (type == typeof(string) || type == typeof(GeoLoc))
                 {
                     ret += $"\"{propertyName}\":\"{hash[propertyName]}\",";
                 }

--- a/test/Redis.OM.Unit.Tests/BasicTypeWithGeoLoc.cs
+++ b/test/Redis.OM.Unit.Tests/BasicTypeWithGeoLoc.cs
@@ -1,0 +1,10 @@
+using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    public class BasicTypeWithGeoLoc
+    {
+        public string Name { get; set; }
+        public GeoLoc Location { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/GeoLocTests.cs
+++ b/test/Redis.OM.Unit.Tests/GeoLocTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests
+{
+    public class GeoLocTests
+    {
+        [Fact]
+        public void TestParsingFromJson()
+        {
+            var str = "{\"Name\":\"Foo\", \"Location\":{\"Longitude\":32.5,\"Latitude\":22.4}}";
+            var basicType = JsonSerializer.Deserialize<BasicTypeWithGeoLoc>(str);
+            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal(32.5, basicType.Location.Longitude);
+            Assert.Equal(22.4, basicType.Location.Latitude);
+        }
+
+        [Fact]
+        public void TestParsingFromFormattedHash()
+        {
+            var hash = new Dictionary<string, string>
+            {
+                {"Name", "Foo"},
+                {"Location", "32.5,22.4"}
+            };
+
+            var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
+            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal(32.5, basicType.Location.Longitude);
+            Assert.Equal(22.4, basicType.Location.Latitude);
+        }
+    }
+}


### PR DESCRIPTION
Improving parsing for geolocs, making the structure not readonly so it can be sent across as JSON and bound properly, adding a missing condition in the object handler so that it is pulled correctly out of redis.