### PR TITLE
Fix omnisharp warnings

### DIFF
--- a/src/Redis.OM.POC/RespHelper.cs
+++ b/src/Redis.OM.POC/RespHelper.cs
@@ -89,7 +89,7 @@ namespace Redis.OM
         public static async Task<RedisReply> ReadBulkStringAsync(Socket socket, string currentString)
         {
             if (currentString == "-1")
-                return null;
+                return "";
             var size = int.Parse(currentString);
             var buffer = new ArraySegment<byte>(new byte[size + 2]);
             //var buffer = new byte[size + 2];
@@ -100,7 +100,7 @@ namespace Redis.OM
         public static RedisReply ReadBulkString(Socket socket, string currentString)
         {
             if (currentString == "-1")
-                return null;
+                return "";
             var size = int.Parse(currentString);
             var buffer = new byte[size+2];
             socket.Receive(buffer);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/GroupByTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/GroupByTests.cs
@@ -46,7 +46,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         [Fact]
         public void TestSimpleGroupBy0()
         {
-            var expectedPredicate = "@Name";
             _mock.Setup(x => x.Execute(
                     "FT.AGGREGATE",
                     "person-idx",


### PR DESCRIPTION
changing null to "" may only hide an inner issue.
But at least it may be seen here.

There are 2 different implementations of `IRedisConnection`
both in `Redis.OM` namespace.
I guess this must be addressed as well but I am not sure how.

https://github.com/redis/redis-om-dotnet/blob/main/src/Redis.OM.POC/RedisConnectionExtensions.cs#L10

Can be closed if considered irrelevant.