### PR TITLE
Refactoring RedisObjectHandler.SetId, Added Integer to the supported RedisIdFieldAttribute

### DIFF
--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -101,35 +101,21 @@ namespace Redis.OM
                 throw new MissingMemberException("Missing Document Attribute decoration");
             }
 
-            string id;
-            id = attr.IdGenerationStrategy.GenerateId();
+            string id = attr.IdGenerationStrategy.GenerateId();
             if (idProperty != null)
             {
-                if (idProperty.GetValue(obj) != default)
+                Type[] supportedIdPropertyTypes = new Type[] { typeof(string), typeof(Guid), typeof(int) };
+                if (supportedIdPropertyTypes.Contains(idProperty.PropertyType))
                 {
-                    id = idProperty.GetValue(obj).ToString();
-                }
-                else
-                {
-                    id = attr.IdGenerationStrategy.GenerateId();
-                }
-
-                if (idProperty.PropertyType == typeof(string))
-                {
-                    idProperty.SetValue(obj, id);
-                }
-                else if (idProperty.PropertyType == typeof(Guid))
-                {
-                    idProperty.SetValue(obj, id);
+                    if (idProperty.GetValue(obj) != null)
+                    {
+                        id = idProperty.GetValue(obj).ToString();
+                    }
                 }
                 else
                 {
                     throw new InvalidOperationException("Software Defined Ids on objects must either be a string or Guid");
                 }
-            }
-            else
-            {
-                id = attr.IdGenerationStrategy.GenerateId();
             }
 
             if (attr.Prefixes == null || string.IsNullOrEmpty(attr.Prefixes.FirstOrDefault()))

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -85,7 +85,7 @@ namespace Redis.OM
         }
 
         /// <summary>
-        /// Set's the id of the given field based off the objects id stratagey.
+        /// Set's the id of the given field based off the objects id strategy.
         /// </summary>
         /// <param name="obj">The object to set the field of.</param>
         /// <returns>The id.</returns>
@@ -101,18 +101,22 @@ namespace Redis.OM
                 throw new MissingMemberException("Missing Document Attribute decoration");
             }
 
-            string id = attr.IdGenerationStrategy.GenerateId();
+            object id = attr.IdGenerationStrategy.GenerateId();
             if (idProperty != null)
             {
-                Type[] supportedIdPropertyTypes = new Type[] { typeof(string), typeof(Guid), typeof(int) };
-                if (!supportedIdPropertyTypes.Contains(idProperty.PropertyType))
+                var supportedIdPropertyTypes = new[] { typeof(string), typeof(Guid), typeof(Ulid) };
+                if (!supportedIdPropertyTypes.Contains(idProperty.PropertyType) && !idProperty.PropertyType.IsValueType)
                 {
-                    throw new InvalidOperationException("Software Defined Ids on objects must either be a string or Guid");
+                    throw new InvalidOperationException("Software Defined Ids on objects must either be a string, ULID, Guid, or some other value type.");
                 }
 
                 if (idProperty.GetValue(obj) != null)
                 {
-                    id = idProperty.GetValue(obj).ToString();
+                    id = idProperty.GetValue(obj);
+                }
+                else
+                {
+                    idProperty.SetValue(obj, id);
                 }
             }
 

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -105,16 +105,14 @@ namespace Redis.OM
             if (idProperty != null)
             {
                 Type[] supportedIdPropertyTypes = new Type[] { typeof(string), typeof(Guid), typeof(int) };
-                if (supportedIdPropertyTypes.Contains(idProperty.PropertyType))
-                {
-                    if (idProperty.GetValue(obj) != null)
-                    {
-                        id = idProperty.GetValue(obj).ToString();
-                    }
-                }
-                else
+                if (!supportedIdPropertyTypes.Contains(idProperty.PropertyType))
                 {
                     throw new InvalidOperationException("Software Defined Ids on objects must either be a string or Guid");
+                }
+
+                if (idProperty.GetValue(obj) != null)
+                {
+                    id = idProperty.GetValue(obj).ToString();
                 }
             }
 

--- a/test/Redis.OM.Unit.Tests/Serialization/ObjectWithIntegerId.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/ObjectWithIntegerId.cs
@@ -1,0 +1,10 @@
+﻿using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    [Document]
+    public class ObjectWithIntegerId
+    {
+        [RedisIdField] public int Id { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/Serialization/ObjectWithStandardId.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/ObjectWithStandardId.cs
@@ -1,0 +1,10 @@
+﻿using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    [Document]
+    public class ObjectWithStandardId
+    {
+        [RedisIdField] public string Id { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/Serialization/ObjectWithUlidId.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/ObjectWithUlidId.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    [Document]
+    public class ObjectWithUlidId
+    {
+        [RedisIdField] public Ulid Id { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
@@ -1,4 +1,5 @@
-﻿using Redis.OM.Contracts;
+﻿using System;
+using Redis.OM.Contracts;
 using Redis.OM.Modeling;
 using Xunit;
 
@@ -28,8 +29,31 @@ namespace Redis.OM.Unit.Tests
             DocumentAttribute.RegisterIdGenerationStrategy(nameof(StaticIncrementStrategy), new StaticIncrementStrategy());
             var obj = new ObjectWithCustomIdGenerationStrategy();
             var id = _connection.Set(obj);
-            Assert.Equal("1", obj.Id);
-            Assert.Equal("1", id.Split(":")[1]);
+            Assert.Equal("0", obj.Id);
+            Assert.Equal("0", id.Split(":")[1]);
+            
+            var obj2 = new ObjectWithCustomIdGenerationStrategy();
+            var id2 = _connection.Set(obj2);
+            Assert.Equal("1", obj2.Id);
+            Assert.Equal("1", id2.Split(":")[1]);
+        }
+
+        [Fact]
+        public void TestUserSetIntId()
+        {
+            var obj = new ObjectWithIntegerId() {Id = 5};
+            var id = _connection.Set(obj);
+            Assert.Equal(5, obj.Id);
+            Assert.Equal("5", id.Split(":")[1]);
+        }
+
+        [Fact]
+        public void TestStandardIdGeneration()
+        {
+            var obj = new ObjectWithStandardId();
+            var id = _connection.Set(obj);
+            var ulid = Ulid.Parse(id.Split(":")[1]);
+            Assert.Equal(ulid.ToString(),obj.Id);
         }
     }
 }


### PR DESCRIPTION
1. Adjusted to an easier-to-maintain types check.
2. Added Int to the supported RedisIdFieldAttribute fields, Integer sounds like a commonly used property for indexing, why would Integers not be accepted?
3. Removed non-working default check on an object type, still checking for null value although it covers only strings.
4. Removed idProperty.SetValue(obj, id) to avoid exceptions when the property is not of type string.