### PR TITLE
generalized solution for compiler generated class expressions

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -154,8 +154,7 @@ namespace Redis.OM.Common
             {
                 if (member.Expression is not ConstantExpression c)
                 {
-                    throw new ArgumentException("Operand for expression must either be an indexed " +
-                                                "field of a model, a literal, or must have a value when expression is enumerated");
+                    return Expression.Lambda(member).Compile().DynamicInvoke().ToString();
                 }
 
                 var val = GetValue(member.Member, c.Value);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using Moq.Language.Flow;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Redis.OM;
 using Redis.OM.Contracts;
@@ -83,6 +84,29 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "LIMIT",
                 "0",
                 "100"));
+        }
+
+        [Fact]
+        public void TestFirstOrDefaultWithMixedLocals()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var heightList = new List<double> {70.0, 68.0};
+            var y = 33;
+            foreach (var height in heightList)
+            {
+                
+                var collection = new RedisCollection<Person>(_mock.Object);
+                var res = collection.FirstOrDefault(x => x.Age == y && x.Height == height);
+                _mock.Verify(x => x.Execute(
+                    "FT.SEARCH",
+                    "person-idx",
+                    $"((@Age:[33 33]) (@Height:[{height} {height}]))",
+                    "LIMIT",
+                    "0",
+                    "1"));
+                
+            }
         }
 
         [Fact]


### PR DESCRIPTION
There are some peculiarities when mixing scopes for compiler-generated class expressions. If everything is an in-scope local the expression will only be one member deep and have a constant expression, however, it looks like if the local is declared out of the immediate scope and you are iterating over something (e.g. a List) that the local generated by the foreach will mix with the out-of-scope local in the generated class and mess with some of the logic in the ExpressionTranslator - it looks like we can overcome this by compiling/invoking the member expression - which might be a bit slower, but definitely more predictable.