### PR TITLE
Search command Fails When the Index was missing

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -189,7 +189,7 @@ namespace Redis.OM.Common
             }
 
             var indexName = string.IsNullOrEmpty(attr.IndexName) ? $"{type.Name.ToLower()}-idx" : attr.IndexName;
-            var query = new RedisQuery { Index = indexName!, QueryText = "*" };
+            var query = new RedisQuery(indexName!) { QueryText = "*" };
             switch (expression)
             {
                 case MethodCallExpression methodExpression:

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -23,6 +23,11 @@ namespace Redis.OM
         public static SearchResponse<T> Search<T>(this IRedisConnection connection, RedisQuery query)
             where T : notnull
         {
+            if (string.IsNullOrEmpty(query.Index))
+            {
+                query.Index = typeof(T).SerializeIndex().FirstOrDefault() ?? string.Empty;
+            }
+
             var res = connection.Execute("FT.SEARCH", query.SerializeQuery());
             return new SearchResponse<T>(res);
         }
@@ -37,6 +42,11 @@ namespace Redis.OM
         public static async Task<SearchResponse<T>> SearchAsync<T>(this IRedisConnection connection, RedisQuery query)
             where T : notnull
         {
+            if (string.IsNullOrEmpty(query.Index))
+            {
+                query.Index = typeof(T).SerializeIndex().FirstOrDefault() ?? string.Empty;
+            }
+
             var res = await connection.ExecuteAsync("FT.SEARCH", query.SerializeQuery());
             return new SearchResponse<T>(res);
         }

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -23,11 +23,6 @@ namespace Redis.OM
         public static SearchResponse<T> Search<T>(this IRedisConnection connection, RedisQuery query)
             where T : notnull
         {
-            if (string.IsNullOrEmpty(query.Index))
-            {
-                query.Index = typeof(T).SerializeIndex().FirstOrDefault() ?? string.Empty;
-            }
-
             var res = connection.Execute("FT.SEARCH", query.SerializeQuery());
             return new SearchResponse<T>(res);
         }
@@ -42,11 +37,6 @@ namespace Redis.OM
         public static async Task<SearchResponse<T>> SearchAsync<T>(this IRedisConnection connection, RedisQuery query)
             where T : notnull
         {
-            if (string.IsNullOrEmpty(query.Index))
-            {
-                query.Index = typeof(T).SerializeIndex().FirstOrDefault() ?? string.Empty;
-            }
-
             var res = await connection.ExecuteAsync("FT.SEARCH", query.SerializeQuery());
             return new SearchResponse<T>(res);
         }

--- a/src/Redis.OM/Searching/Query/RedisQuery.cs
+++ b/src/Redis.OM/Searching/Query/RedisQuery.cs
@@ -9,6 +9,16 @@ namespace Redis.OM.Searching.Query
     public sealed class RedisQuery
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="RedisQuery"/> class.
+        /// An object to facilitate the Raw Redis query.
+        /// </summary>
+        /// <param name="index">Name of the Index to query.</param>
+        public RedisQuery(string index)
+        {
+            this.Index = index;
+        }
+
+        /// <summary>
         /// Gets or sets the flags for the query options.
         /// </summary>
         public long Flags { get; set; } = 0;
@@ -16,7 +26,7 @@ namespace Redis.OM.Searching.Query
         /// <summary>
         /// Gets or sets the index to query.
         /// </summary>
-        public string Index { get; set; } = string.Empty;
+        public string Index { get; set; }
 
         /// <summary>
         /// Gets or sets the query text.


### PR DESCRIPTION
### Context:
I was experimenting with the code and found the search extension method which allows me to work on the low-level API. So I tried the same
``` csharp
SearchResponse<Movies> searchResponse = provider
        .Connection
        .Search<Movies>(new RedisQuery { QueryText = "war" });
    foreach (var item in searchResponse.Documents)
    {
        Console.WriteLine(item.Value.Title);
    }
```
I got an Argument Null exception as IndexName is one of the mandatory parameters. Since my index is automatically created by the library, I took some time to find the index pattern. 

### Solution: 
Since we are already passing the Generics we can use the code

``` csharp 
 query.Index = typeof(T).SerializeIndex().FirstOrDefault() ?? string.Empty;
```
or use the below code
``` csharp
var objAttribute = Attribute.GetCustomAttribute(
        type,
        typeof(DocumentAttribute)) as DocumentAttribute;
    if (objAttribute == null)
    {
        throw new InvalidOperationException($"Type being indexed must be decorated " +
            $"with an RedisObjectDefinitionAttribute, none found on provided type:{type.Name}");
    }

    var args = new List<string>();
    if (string.IsNullOrEmpty(objAttribute.IndexName))
    {
        args.Add($"{type.Name.ToLower()}-idx");
    }
    else
    {
        args.Add(objAttribute.IndexName!);
    }
```

as done in other places. 

**I have not added the Unit test yet. I want to validate the idea to verify if it is done intentionally.** 
