### PR TITLE
Fix old redis-developer links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * @simonprickett
 * @BenShapira
 * @satish860
+* @dracco1993
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 **Redis OM .NET** makes it easy to model Redis data in your .NET Applications.
 
-**Redis OM .NET** | [Redis OM Node.js][redis-om-js] | [Redis OM Spring][redis-om-spring] | [Redis OM Python][redis-om-python]
+**Redis OM .NET** | [Redis OM Node.js](https://github.com/redis/redis-om-node) | [Redis OM Spring](https://github.com/redis/redis-om-spring) | [Redis OM Python](https://github.com/redis/redis-om-python)
 
 <details>
   <summary><strong>Table of contents</strong></summary>


### PR DESCRIPTION
When browsing through the README, I noticed some of the links were based on an old code location, so I have updated those in this PR, and the PRs linked below for each repo:
redis/redis-om-dotnet#46
redis/redis-om-node#37
redis/redis-om-python/pull/95
redis/redis-om-spring#14