### PR TITLE
Fixed GeoLoc wrong parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * @BenShapira
 * @satish860
 * @dracco1993
+* @ecortese
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Modeling/GeoLocJsonConverter.cs
+++ b/src/Redis.OM/Modeling/GeoLocJsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -25,7 +26,8 @@ namespace Redis.OM.Modeling
                 var split = str.Split(',');
                 if (split.Length == 2)
                 {
-                    if (double.TryParse(split[0], out var lon) && double.TryParse(split[1], out var lat))
+                    if (double.TryParse(split[0], NumberStyles.Number, CultureInfo.InvariantCulture, out var lon) &&
+                        double.TryParse(split[1], NumberStyles.Number, CultureInfo.InvariantCulture, out var lat))
                     {
                         return new GeoLoc(lon, lat);
                     }

--- a/test/Redis.OM.Unit.Tests/GeoLocTests.cs
+++ b/test/Redis.OM.Unit.Tests/GeoLocTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -11,7 +12,7 @@ namespace Redis.OM.Unit.Tests
         {
             var str = "{\"Name\":\"Foo\", \"Location\":{\"Longitude\":32.5,\"Latitude\":22.4}}";
             var basicType = JsonSerializer.Deserialize<BasicTypeWithGeoLoc>(str);
-            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal("Foo", basicType.Name);
             Assert.Equal(32.5, basicType.Location.Longitude);
             Assert.Equal(22.4, basicType.Location.Latitude);
         }
@@ -26,9 +27,50 @@ namespace Redis.OM.Unit.Tests
             };
 
             var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
-            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal("Foo", basicType.Name);
             Assert.Equal(32.5, basicType.Location.Longitude);
             Assert.Equal(22.4, basicType.Location.Latitude);
+        }
+
+        /// <summary>
+        /// This test will pass only if parsing of formatted geoloc string values is culture invariant.
+        /// It will fail for example when the process runs in an environment having a culture that use a comma (",") or any other char different from dot (".")
+        /// as number decimal separator (e.g. it-IT culture).
+        /// </summary>
+        [Fact]
+        public void TestInvariantCultureParsingFromFormattedHash()
+        {
+            // store original process culture objects
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                var differentCulture = new System.Globalization.CultureInfo("it-IT");
+
+                Assert.NotEqual(".", differentCulture.NumberFormat.NumberDecimalSeparator);
+
+                // set a different culture for the current thread
+                Thread.CurrentThread.CurrentCulture = differentCulture;
+                Thread.CurrentThread.CurrentUICulture = differentCulture;
+
+                var hash = new Dictionary<string, string>
+                {
+                    {"Name", "Foo"},
+                    {"Location", "32.5,22.4"}
+                };
+
+                var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
+                Assert.Equal("Foo", basicType.Name);
+                Assert.Equal(32.5, basicType.Location.Longitude);
+                Assert.Equal(22.4, basicType.Location.Latitude);
+            }
+            finally
+            {
+                // restore original process culture objects
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+                Thread.CurrentThread.CurrentUICulture = currentUICulture;
+            }
         }
     }
 }


### PR DESCRIPTION
Made parsing of longitude and latitude values process culture independent.

Before this fix GeoLocTests.TestParsingFromFormattedHash test fails when process culture define use of comma char as decimal separator for numbers or any other char different from the dot char.
