### PR TITLE
Added TestInvariantCultureParsingFromFormattedHash test

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * @BenShapira
 * @satish860
 * @dracco1993
+* @ecortese
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/test/Redis.OM.Unit.Tests/GeoLocTests.cs
+++ b/test/Redis.OM.Unit.Tests/GeoLocTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -11,7 +12,7 @@ namespace Redis.OM.Unit.Tests
         {
             var str = "{\"Name\":\"Foo\", \"Location\":{\"Longitude\":32.5,\"Latitude\":22.4}}";
             var basicType = JsonSerializer.Deserialize<BasicTypeWithGeoLoc>(str);
-            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal("Foo", basicType.Name);
             Assert.Equal(32.5, basicType.Location.Longitude);
             Assert.Equal(22.4, basicType.Location.Latitude);
         }
@@ -26,9 +27,50 @@ namespace Redis.OM.Unit.Tests
             };
 
             var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
-            Assert.Equal("Foo",basicType.Name);
+            Assert.Equal("Foo", basicType.Name);
             Assert.Equal(32.5, basicType.Location.Longitude);
             Assert.Equal(22.4, basicType.Location.Latitude);
+        }
+
+        /// <summary>
+        /// This test will pass only if parsing of formatted geoloc string values is culture invariant.
+        /// It will fail for example when the process runs in an environment having a culture that use a comma (",") or any other char different from dot (".")
+        /// as number decimal separator (e.g. it-IT culture).
+        /// </summary>
+        [Fact]
+        public void TestInvariantCultureParsingFromFormattedHash()
+        {
+            // store original process culture objects
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                var differentCulture = new System.Globalization.CultureInfo("it-IT");
+
+                Assert.NotEqual(".", differentCulture.NumberFormat.NumberDecimalSeparator);
+
+                // set a different culture for the current thread
+                Thread.CurrentThread.CurrentCulture = differentCulture;
+                Thread.CurrentThread.CurrentUICulture = differentCulture;
+
+                var hash = new Dictionary<string, string>
+                {
+                    {"Name", "Foo"},
+                    {"Location", "32.5,22.4"}
+                };
+
+                var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
+                Assert.Equal("Foo", basicType.Name);
+                Assert.Equal(32.5, basicType.Location.Longitude);
+                Assert.Equal(22.4, basicType.Location.Latitude);
+            }
+            finally
+            {
+                // restore original process culture objects
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+                Thread.CurrentThread.CurrentUICulture = currentUICulture;
+            }
         }
     }
 }


### PR DESCRIPTION
I added a new test to show the missing of invariant culture logic when parsing geoloc values stored as string.
It will enforce the Redis.OM.Unit.Tests.GeoLocTests.TestParsingFromFormattedHash test method that is currently failing when test are performed in an evironment having a culture that use a comma or any other character different from the dot char as number decimal separator (e.g. it-IT, fr-FR, etc.).
