### PR TITLE
Enforced culture invariant compliance

### DIFF
--- a/src/Redis.OM.Analyzer/Redis.OM.Analyzer.csproj
+++ b/src/Redis.OM.Analyzer/Redis.OM.Analyzer.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
   </ItemGroup>
 
 

--- a/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using Redis.OM.Searching;
 
 namespace Redis.OM.Aggregation.AggregationPredicates
@@ -40,7 +41,7 @@ namespace Redis.OM.Aggregation.AggregationPredicates
         public IEnumerable<string> Serialize()
         {
             var numArgs = Max.HasValue ? 4 : 2;
-            var ret = new List<string> { "SORTBY", numArgs.ToString(), $"@{Property}", Direction == SortDirection.Ascending ? "ASC" : "DESC" };
+            var ret = new List<string> { "SORTBY", numArgs.ToString(CultureInfo.InvariantCulture), $"@{Property}", Direction == SortDirection.Ascending ? "ASC" : "DESC" };
             if (Max.HasValue)
             {
                 ret.Add("MAX");

--- a/src/Redis.OM/Aggregation/AggregationPredicates/ApplyFunctions.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/ApplyFunctions.cs
@@ -9,6 +9,8 @@ namespace Redis.OM.Aggregation.AggregationPredicates
     /// </summary>
     public static class ApplyFunctions
     {
+        private const double RADIANTTODEGREESCONST = Math.PI / 180.0;
+
         /// <summary>
         /// checks if the field exists on the object in redis.
         /// </summary>
@@ -265,10 +267,10 @@ namespace Redis.OM.Aggregation.AggregationPredicates
         /// <returns>distance in meters.</returns>
         public static double GeoDistance(double longitude, double latitude, double otherLongitude, double otherLatitude)
         {
-            var d1 = latitude * (Math.PI / 180.0);
-            var num1 = longitude * (Math.PI / 180.0);
-            var d2 = otherLatitude * (Math.PI / 180.0);
-            var num2 = (otherLongitude * (Math.PI / 180.0)) - num1;
+            var d1 = latitude * RADIANTTODEGREESCONST;
+            var num1 = longitude * RADIANTTODEGREESCONST;
+            var d2 = otherLatitude * RADIANTTODEGREESCONST;
+            var num2 = (otherLongitude * RADIANTTODEGREESCONST) - num1;
             var d3 = Math.Pow(Math.Sin((d2 - d1) / 2.0), 2.0) + (Math.Cos(d1) * Math.Cos(d2) * Math.Pow(Math.Sin(num2 / 2.0), 2.0));
 
             return 6376500.0 * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -17,9 +17,6 @@ namespace Redis.OM.Common
     /// </summary>
     internal static class ExpressionParserUtilities
     {
-        private const string SYSTEMDOUBLETYPE = "System.Double";
-        private const string SYSTEMSTRINGTYPE = "System.String";
-
         /// <summary>
         /// Get's the operand string.
         /// </summary>
@@ -405,30 +402,26 @@ namespace Redis.OM.Common
 
         private static string ValueToString(object value)
         {
-            return value.GetType().FullName switch
-            {
-                SYSTEMDOUBLETYPE => ((double)value).ToString(CultureInfo.InvariantCulture),
-                _ => value.ToString(),
-            };
-        }
+            Type valueType = value.GetType();
 
-        private static string ConstantToString(ConstantExpression constExp)
-        {
-            return constExp.Type.FullName switch
+            if (valueType == typeof(double) || Nullable.GetUnderlyingType(valueType) == typeof(double))
             {
-                SYSTEMDOUBLETYPE => $"{((double)constExp.Value).ToString(CultureInfo.InvariantCulture)}",
-                _ => $"{constExp.Value}",
-            };
+                return ((double)value).ToString(CultureInfo.InvariantCulture);
+            }
+
+            return value.ToString();
         }
 
         private static string GetConstantStringForArgs(ConstantExpression constExp)
         {
-            return constExp.Type.FullName switch
+            string valueAsString = ValueToString(constExp.Value);
+
+            if (constExp.Type == typeof(string))
             {
-                SYSTEMSTRINGTYPE => $"\"{constExp.Value}\"",
-                SYSTEMDOUBLETYPE => $"{((double)constExp.Value).ToString(CultureInfo.InvariantCulture)}",
-                _ => $"{constExp.Value}",
-            };
+                return $"\"{valueAsString}\"";
+            }
+
+            return $"{valueAsString}";
         }
     }
 }

--- a/src/Redis.OM/GeoLoc.cs
+++ b/src/Redis.OM/GeoLoc.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Redis.OM.Modeling
 {
@@ -39,7 +40,8 @@ namespace Redis.OM.Modeling
             var arr = geolocString.Split(',');
             if (arr.Length == 2)
             {
-                if (double.TryParse(arr[0], out var lon) && double.TryParse(arr[1], out var lat))
+                if (double.TryParse(arr[0], NumberStyles.Number, CultureInfo.InvariantCulture, out var lon) &&
+                    double.TryParse(arr[1], NumberStyles.Number, CultureInfo.InvariantCulture, out var lat))
                 {
                     return new GeoLoc(lon, lat);
                 }

--- a/src/Redis.OM/RedisReply.cs
+++ b/src/Redis.OM/RedisReply.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using StackExchange.Redis;
 
@@ -100,7 +101,7 @@ namespace Redis.OM
                 return (double)v._internalDouble;
             }
 
-            if (v._internalString != null && double.TryParse(v._internalString, out var ret))
+            if (v._internalString != null && double.TryParse(v._internalString, NumberStyles.Number, CultureInfo.InvariantCulture, out var ret))
             {
                 return ret;
             }

--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -181,7 +181,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(CountDistinctAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<long>(exp, typeof(T));
         }
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(StandardDeviationAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double>(exp, typeof(T));
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(FirstValue, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<TResult>(exp, typeof(T));
         }
 
         /// <summary>
@@ -397,7 +397,7 @@ namespace Redis.OM
                 Expression.Quote(expression),
                 Expression.Constant(sortedBy),
                 Expression.Constant(direction));
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<TResult>(exp, typeof(T));
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(FirstValueAsync, source, expression, sortedBy),
                 new[] { source.Expression, Expression.Quote(expression), Expression.Constant(sortedBy) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<TResult>(exp, typeof(T));
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(Quantile, source, expression, quantile),
                 new[] { source.Expression, Expression.Quote(expression), Expression.Constant(quantile) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<TResult>(exp, typeof(T));
         }
 
         /// <summary>
@@ -565,7 +565,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(CountDistinctish, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<long>(exp, typeof(T));
         }
 
         /// <summary>
@@ -904,7 +904,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double>(exp, typeof(T));
         }
 
         /// <summary>
@@ -920,7 +920,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<int>(exp, typeof(T));
         }
 
         /// <summary>
@@ -936,7 +936,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<long>(exp, typeof(T));
         }
 
         /// <summary>
@@ -952,7 +952,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<float>(exp, typeof(T));
         }
 
         /// <summary>
@@ -968,7 +968,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<decimal>(exp, typeof(T));
         }
 
         /// <summary>
@@ -984,7 +984,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1000,7 +1000,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<int?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1016,7 +1016,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<long?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1032,7 +1032,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<float?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1048,7 +1048,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(SumAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<decimal?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1064,7 +1064,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1080,7 +1080,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1096,7 +1096,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1112,7 +1112,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<float>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1128,7 +1128,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<decimal>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1144,7 +1144,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<double?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1160,7 +1160,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<int?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1176,7 +1176,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<long?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1192,7 +1192,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<float?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1208,7 +1208,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(AverageAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<decimal?>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1224,7 +1224,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(MaxAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<int>(exp, typeof(T));
         }
 
         /// <summary>
@@ -1240,7 +1240,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(MinAsync, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync(exp, typeof(T));
+            return await ((RedisQueryProvider)source.Provider).ExecuteReductiveAggregationAsync<T>(exp, typeof(T));
         }
 
         private static MethodInfo GetMethodInfo<T1, T2>(Func<T1, T2> f)

--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -230,6 +230,11 @@ namespace Redis.OM.Searching
 
         private static RedisReply InvariantCultureResultParsing<T>(RedisReply value)
         {
+            if (string.IsNullOrEmpty(value.ToString()) && Nullable.GetUnderlyingType(typeof(T)) != null)
+            {
+                return value;
+            }
+
             return typeof(T).FullName switch
             {
                 SYSTEMDOUBLETYPE => /*

--- a/test/Redis.OM.Unit.Tests/GeoLocTests.cs
+++ b/test/Redis.OM.Unit.Tests/GeoLocTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -34,43 +33,11 @@ namespace Redis.OM.Unit.Tests
 
         /// <summary>
         /// This test will pass only if parsing of formatted geoloc string values is culture invariant.
-        /// It will fail for example when the process runs in an environment having a culture that use a comma (",") or any other char different from dot (".")
-        /// as number decimal separator (e.g. it-IT culture).
         /// </summary>
         [Fact]
         public void TestInvariantCultureParsingFromFormattedHash()
         {
-            // store original process culture objects
-            var currentCulture = Thread.CurrentThread.CurrentCulture;
-            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            try
-            {
-                var differentCulture = new System.Globalization.CultureInfo("it-IT");
-
-                Assert.NotEqual(".", differentCulture.NumberFormat.NumberDecimalSeparator);
-
-                // set a different culture for the current thread
-                Thread.CurrentThread.CurrentCulture = differentCulture;
-                Thread.CurrentThread.CurrentUICulture = differentCulture;
-
-                var hash = new Dictionary<string, string>
-                {
-                    {"Name", "Foo"},
-                    {"Location", "32.5,22.4"}
-                };
-
-                var basicType = RedisObjectHandler.FromHashSet<BasicTypeWithGeoLoc>(hash);
-                Assert.Equal("Foo", basicType.Name);
-                Assert.Equal(32.5, basicType.Location.Longitude);
-                Assert.Equal(22.4, basicType.Location.Latitude);
-            }
-            finally
-            {
-                // restore original process culture objects
-                Thread.CurrentThread.CurrentCulture = currentCulture;
-                Thread.CurrentThread.CurrentUICulture = currentUICulture;
-            }
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestParsingFromFormattedHash());
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/Helper.cs
+++ b/test/Redis.OM.Unit.Tests/Helper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests
+{
+    internal class Helper
+    {
+        internal static void RunTestUnderDifferentCulture(string lcid, Action<object> test)
+        {
+            if (lcid == null)
+                throw new ArgumentNullException(nameof(lcid));
+
+            if (test == null)
+                throw new ArgumentNullException(nameof(lcid));
+
+            var differentCulture = new System.Globalization.CultureInfo(lcid);
+
+            Assert.NotEqual(".", differentCulture.NumberFormat.NumberDecimalSeparator);
+
+            // set a different culture for the current thread
+            Thread.CurrentThread.CurrentCulture = differentCulture;
+            Thread.CurrentThread.CurrentUICulture = differentCulture;
+
+            test.Invoke(null);
+        }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationFunctionalTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Redis.OM.Aggregation;
+﻿using Redis.OM.Aggregation;
 using Redis.OM.Contracts;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests.RediSearchTests
@@ -133,6 +130,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                     .StandardDeviationAsync(x => x["AdjustedSales"]);
                 Assert.Equal(358018.854252, stddev);
             }).GetAwaiter().GetResult();
+        }
+
+        [Fact]
+        public void GetAdjustedSalesStandardDeviationTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => GetAdjustedSalesStandardDeviation());
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
@@ -1,11 +1,10 @@
 ﻿using Moq;
-using System;
-using System.Linq;
 using Redis.OM.Aggregation;
 using Redis.OM.Aggregation.AggregationPredicates;
 using Redis.OM.Contracts;
-using Redis.OM;
 using Redis.OM.Modeling;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests.RediSearchTests
@@ -820,6 +819,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestGeoDistance1Field2coordsTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Field2coords());
+        }
+
+        [Fact]
         public void TestGeoDistance1String2Field()
         {
             var expectedPredicate = "geodistance(\"1.5,3.2\",@Work)";
@@ -880,6 +885,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestGeoDistance1String2CoordsTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1String2Coords());
+        }
+
+        [Fact]
         public void TestGeoDistance1Coord2Field()
         {
             var expectedPredicate = "geodistance(1.5,3.2,@Work)";
@@ -897,6 +908,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 x => ApplyFunctions.GeoDistance(1.5,3.2, (GeoLoc)x.RecordShell.Work), "geo").ToArray();
 
             Assert.Equal("Blah", res[0]["FakeResult"]);
+        }
+
+        [Fact]
+        public void TestGeoDistance1Coord2FieldTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Coord2Field());
         }
 
         [Fact]
@@ -920,6 +937,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestGeoDistance1Coord2StringTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Coord2String());
+        }
+
+        [Fact]
         public void TestGeoDistance1Coord2Cord()
         {
             var expectedPredicate = "geodistance(1.5,3.2,1.5,3.2)";
@@ -937,6 +960,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 x => ApplyFunctions.GeoDistance(1.5, 3.2, 1.5,3.2), "geo").ToArray();
 
             Assert.Equal("Blah", res[0]["FakeResult"]);
+        }
+
+        [Fact]
+        public void TestGeoDistance1Coord2CordTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Coord2Cord());
         }
 
         [Fact]
@@ -960,6 +989,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestGeoDistance1Coord2CordAdditionTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Coord2CordAddition());
+        }
+
+        [Fact]
         public void TestGeoDistance1Coord2CordNonLiteral()
         {
             var expectedPredicate = "geodistance(1.5,3.2,1.5,3.2)";
@@ -979,6 +1014,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 x => ApplyFunctions.GeoDistance(lon1, lat1, 1.5, 3.2), "geo").ToArray();
 
             Assert.Equal("Blah", res[0]["FakeResult"]);
+        }
+
+        [Fact]
+        public void TestGeoDistance1Coord2CordNonLiteralTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestGeoDistance1Coord2CordNonLiteral());
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ReducerTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ReducerTests.cs
@@ -1,10 +1,10 @@
 ﻿using Moq;
-using System.Linq;
-using System.Threading.Tasks;
+using Redis.OM;
 using Redis.OM.Aggregation;
 using Redis.OM.Contracts;
-using Redis.OM;
 using Redis.OM.Searching;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests.RediSearchTests
@@ -648,6 +648,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestQuantileNoGroupPredicateTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestQuantileNoGroupPredicate());
+        }
+
+        [Fact]
         public void TestQuantileNoGroupPredicateAsync()
         {
             var mockReply = new RedisReply[]
@@ -681,9 +687,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 var res = await collection.QuantileAsync(x => x.RecordShell.Age, .7);
                 Assert.Equal(5, res);
             }).GetAwaiter().GetResult();
-            
+        }
 
-            
+        [Fact]
+        public void TestQuantileNoGroupPredicateAsyncTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestQuantileNoGroupPredicateAsync());
         }
 
         [Fact]
@@ -723,6 +732,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 .ToArray();
 
             Assert.Equal(5, (int)res[0]["Age_QUANTILE_0.7"]);
+        }
+
+        [Fact]
+        public void TestQuantileWithGroupPredicateTestingInvariantCultureCompliance()
+        {
+            Helper.RunTestUnderDifferentCulture("it-IT", x => TestQuantileWithGroupPredicate());
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes all tests that fails when executed in an environment using a culture where the decimal number separator character isn't a dot char (e.g. it-IT, fr-FR, etc.).
For any failing test I've added a namesake one with the suffix "TestingInvariantCultureCompliance" where test runs on different process culture.