### PR TITLE
DateTimeOffsetParsing for hash

### DIFF
--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -195,6 +195,14 @@ namespace Redis.OM
                         hash.Add(propertyName, val.ToString());
                     }
                 }
+                else if (type == typeof(DateTimeOffset))
+                {
+                    var val = (DateTimeOffset)property.GetValue(obj);
+                    if (val != null)
+                    {
+                        hash.Add(propertyName, val.ToString("O"));
+                    }
+                }
                 else if (type == typeof(DateTime) || type == typeof(DateTime?))
                 {
                     var val = (DateTime)property.GetValue(obj);
@@ -264,7 +272,7 @@ namespace Redis.OM
                 {
                     ret += $"\"{propertyName}\":{hash[propertyName]},";
                 }
-                else if (type == typeof(string) || type == typeof(GeoLoc) || type == typeof(DateTime) || type == typeof(DateTime?))
+                else if (type == typeof(string) || type == typeof(GeoLoc) || type == typeof(DateTime) || type == typeof(DateTime?) || type == typeof(DateTimeOffset))
                 {
                     ret += $"\"{propertyName}\":\"{hash[propertyName]}\",";
                 }

--- a/test/Redis.OM.Unit.Tests/Serialization/ObjectWithDateTimeOffset.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/ObjectWithDateTimeOffset.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    [Document]
+    public class ObjectWithDateTimeOffset
+    {
+        public DateTimeOffset Offset { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
@@ -55,5 +55,19 @@ namespace Redis.OM.Unit.Tests
             var ulid = Ulid.Parse(id.Split(":")[1]);
             Assert.Equal(ulid.ToString(),obj.Id);
         }
+        [Fact]
+        public void TestDateTimeOffset()
+        {
+            var obj = new ObjectWithDateTimeOffset
+            {
+                Offset = DateTimeOffset.Now
+            };
+
+            var id = _connection.Set(obj);
+
+            var alsoObj = _connection.Get<ObjectWithDateTimeOffset>(id);
+            Assert.Equal(obj.Offset, alsoObj.Offset);
+        }
+
     }
 }


### PR DESCRIPTION
Should fix #50 - `DateTimeOffset` was causing infinite recursive when not explicitly pulled out, saving as ISO8601 timestamp for the hash field.