### PR TITLE
Exception handling for index creation/deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * @satish860
 * @dracco1993
 * @ecortese
+* @DanJRWalsh
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -49,9 +49,21 @@ namespace Redis.OM
         /// <returns>whether the index was created or not.</returns>
         public static bool CreateIndex(this IRedisConnection connection, Type type)
         {
-            var serializedParams = type.SerializeIndex();
-            connection.Execute("FT.CREATE", serializedParams);
-            return true;
+            try
+            {
+                var serializedParams = type.SerializeIndex();
+                connection.Execute("FT.CREATE", serializedParams);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Index already exists"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
         }
 
         /// <summary>
@@ -62,9 +74,21 @@ namespace Redis.OM
         /// <returns>whether the index was created or not.</returns>
         public static async Task<bool> CreateIndexAsync(this IRedisConnection connection, Type type)
         {
-            var serializedParams = type.SerializeIndex();
-            await connection.ExecuteAsync("FT.CREATE", serializedParams);
-            return true;
+            try
+            {
+                var serializedParams = type.SerializeIndex();
+                await connection.ExecuteAsync("FT.CREATE", serializedParams);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Index already exists"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -143,31 +143,6 @@ namespace Redis.OM
         }
 
         /// <summary>
-        /// Deletes an index. And drops associated records.
-        /// </summary>
-        /// <param name="connection">the connection.</param>
-        /// <param name="type">the type to drop the index for.</param>
-        /// <returns>whether the index was dropped or not.</returns>
-        public static async Task<bool> DropIndexAndAssociatedRecordsAsync(this IRedisConnection connection, Type type)
-        {
-            try
-            {
-                var indexName = type.SerializeIndex().First();
-                await connection.ExecuteAsync("FT.DROPINDEX", indexName, "DD");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                if (ex.Message.Contains("Unknown Index name"))
-                {
-                    return false;
-                }
-
-                throw;
-            }
-        }
-
-        /// <summary>
         /// Search redis with the given query.
         /// </summary>
         /// <param name="connection">the connection to redis.</param>

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -75,9 +75,21 @@ namespace Redis.OM
         /// <returns>whether the index was dropped or not.</returns>
         public static async Task<bool> DropIndexAsync(this IRedisConnection connection, Type type)
         {
-            var indexName = type.SerializeIndex().First();
-            await connection.ExecuteAsync("FT.DROPINDEX", indexName);
-            return true;
+            try
+            {
+                var indexName = type.SerializeIndex().First();
+                await connection.ExecuteAsync("FT.DROPINDEX", indexName);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -131,6 +131,31 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Deletes an index. And drops associated records.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to drop the index for.</param>
+        /// <returns>whether the index was dropped or not.</returns>
+        public static async Task<bool> DropIndexAndAssociatedRecordsAsync(this IRedisConnection connection, Type type)
+        {
+            try
+            {
+                var indexName = type.SerializeIndex().First();
+                await connection.ExecuteAsync("FT.DROPINDEX", indexName, "DD");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Search redis with the given query.
         /// </summary>
         /// <param name="connection">the connection to redis.</param>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Redis.OM;
-using Xunit;
 using Redis.OM.Modeling;
+using Xunit;
 
-namespace Redis.OM.Unit.Tests
+namespace Redis.OM.Unit.Tests.RediSearchTests
 {
     public class RedisIndexTests
     {        
@@ -38,7 +35,7 @@ namespace Redis.OM.Unit.Tests
         public void TestIndexSerializationHappyPath()
         {
             var expected = new[] { "TestPersonClassHappyPath-idx",
-                "ON", "Hash", "PREFIX", "1", "Redis.OM.Unit.Tests.RedisIndexTests+TestPersonClassHappyPath:", "SCHEMA",
+                "ON", "Hash", "PREFIX", "1", "Redis.OM.Unit.Tests.RediSearchTests.RedisIndexTests+TestPersonClassHappyPath:", "SCHEMA",
                 "Name", "TEXT", "SORTABLE", "Age", "NUMERIC", "SORTABLE" };
             var indexArr = typeof(TestPersonClassHappyPath).SerializeIndex();
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
@@ -69,6 +69,30 @@ namespace Redis.OM.Unit.Tests
         }
         
         [Fact]
+        public async Task TestCreateIndexAsync()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+            var res = await connection.CreateIndexAsync(typeof(TestPersonClassHappyPath));            
+            Assert.True(res);
+            await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+        }
+
+        [Fact]
+        public void TestCreateAlreadyExistingIndex()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            connection.CreateIndex(typeof(TestPersonClassHappyPath));  
+            var res = connection.CreateIndex(typeof(TestPersonClassHappyPath));
+            Assert.False(res);
+            connection.DropIndex(typeof(TestPersonClassHappyPath));
+        }
+        
+        [Fact]
         public void TestDropExistingIndex()
         {
             var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
@@ -81,6 +105,18 @@ namespace Redis.OM.Unit.Tests
         }
 
         [Fact]
+        public async Task TestDropExistingIndexAsync()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+            await connection.CreateIndexAsync(typeof(TestPersonClassHappyPath));            
+            var res = await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+            Assert.True(res);
+        }
+
+        [Fact]
         public void TestDropIndexWhichDoesNotExist()
         {
             var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
@@ -88,6 +124,17 @@ namespace Redis.OM.Unit.Tests
             var connection = provider.Connection;
             connection.DropIndex(typeof(TestPersonClassHappyPath));
             var res = connection.DropIndex(typeof(TestPersonClassHappyPath));
+            Assert.False(res);
+        }
+        
+        [Fact]
+        public async Task TestDropIndexWhichDoesNotExistAsync()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+            var res = await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
             Assert.False(res);
         }
     }


### PR DESCRIPTION
Added missing exception handling to `CreateIndex`, `CreateIndexAsync` and `DropIndexAsync`