### PR TITLE
Single record updates / deletes

### DIFF
--- a/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
+++ b/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
@@ -20,8 +20,6 @@ namespace Redis.OM.Modeling
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
 
-        private readonly DocumentAttribute _documentAttribute;
-
         static RedisCollectionStateManager()
         {
             JsonSerializerOptions.Converters.Add(new GeoLocJsonConverter());
@@ -34,8 +32,13 @@ namespace Redis.OM.Modeling
         /// <param name="attr">The document attribute for the type.</param>
         public RedisCollectionStateManager(DocumentAttribute attr)
         {
-            _documentAttribute = attr;
+            DocumentAttribute = attr;
         }
+
+        /// <summary>
+        /// Gets the DocumentAttribute for the underlying type.
+        /// </summary>
+        public DocumentAttribute DocumentAttribute { get; }
 
         /// <summary>
         /// Gets a snapshot from when the collection enumerated.
@@ -48,18 +51,26 @@ namespace Redis.OM.Modeling
         internal IDictionary<string, object?> Data { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
+        /// Add item to data.
+        /// </summary>
+        /// <param name="key">the item's key.</param>
+        /// <param name="value">the item's value.</param>
+        internal void InsertIntoData(string key, object value)
+        {
+            Data.Remove(key);
+            Data.Add(key, value);
+        }
+
+        /// <summary>
         /// Add item to snapshot.
         /// </summary>
         /// <param name="key">the item's key.</param>
         /// <param name="value">the current value of the item.</param>
         internal void InsertIntoSnapshot(string key, object value)
         {
-            if (Snapshot.ContainsKey(key))
-            {
-                return;
-            }
+            Snapshot.Remove(key);
 
-            if (_documentAttribute.StorageType == StorageType.Json)
+            if (DocumentAttribute.StorageType == StorageType.Json)
             {
                 var json = JToken.FromObject(value, Newtonsoft.Json.JsonSerializer.Create(new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
                 Snapshot.Add(key, json);
@@ -72,13 +83,52 @@ namespace Redis.OM.Modeling
         }
 
         /// <summary>
+        /// Builds a diff for a single object from what's currently in the snapshot.
+        /// </summary>
+        /// <param name="key">the key of the object in redis.</param>
+        /// <param name="value">The current value.</param>
+        /// <param name="differences">The detected differences.</param>
+        /// <returns>Whether a diff could be constructed.</returns>
+        internal bool TryDetectDifferencesSingle(string key, object value, out IList<IObjectDiff>? differences)
+        {
+            if (!Snapshot.ContainsKey(key))
+            {
+                differences = null;
+                return false;
+            }
+
+            if (DocumentAttribute.StorageType == StorageType.Json)
+            {
+                var dataJson = JsonSerializer.Serialize(value, JsonSerializerOptions);
+                var current = JsonConvert.DeserializeObject<JObject>(dataJson, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                var snapshot = (JToken)Snapshot[key];
+                var diff = FindDiff(current!, snapshot);
+                differences = BuildJsonDifference(diff, "$");
+            }
+            else
+            {
+                var dataHash = value.BuildHashSet();
+                var snapshotHash = (IDictionary<string, string>)Snapshot[key];
+                var deletedKeys = snapshotHash.Keys.Except(dataHash.Keys).Select(x => new KeyValuePair<string, string>(x, string.Empty));
+                var modifiedKeys = dataHash.Where(x =>
+                    !snapshotHash.Keys.Contains(x.Key) || snapshotHash[x.Key] != x.Value);
+                differences = new List<IObjectDiff>
+                {
+                    new HashDiff(modifiedKeys, deletedKeys.Select(x => x.Key)),
+                };
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Detects the differences.
         /// </summary>
         /// <returns>a difference dictionary.</returns>
         internal IDictionary<string, IList<IObjectDiff>> DetectDifferences()
         {
             var res = new Dictionary<string, IList<IObjectDiff>>();
-            if (_documentAttribute.StorageType == StorageType.Json)
+            if (DocumentAttribute.StorageType == StorageType.Json)
             {
                 foreach (var key in Snapshot.Keys)
                 {
@@ -267,8 +317,12 @@ namespace Redis.OM.Modeling
 
                     break;
                 default:
-                    diff["+"] = currentObject;
-                    diff["-"] = snapshotObject;
+                    if (currentObject.ToString() != snapshotObject.ToString())
+                    {
+                        diff["+"] = currentObject;
+                        diff["-"] = snapshotObject;
+                    }
+
                     break;
             }
 

--- a/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
+++ b/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
@@ -51,6 +51,16 @@ namespace Redis.OM.Modeling
         internal IDictionary<string, object?> Data { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
+        /// Removes the key from the data and snapshot.
+        /// </summary>
+        /// <param name="key">The key to remove.</param>
+        internal void Remove(string key)
+        {
+            Snapshot.Remove(key);
+            Data.Remove(key);
+        }
+
+        /// <summary>
         /// Add item to data.
         /// </summary>
         /// <param name="key">the item's key.</param>

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -365,6 +365,14 @@ namespace Redis.OM
         public static string Unlink(this IRedisConnection connection, string key) => connection.Execute("UNLINK", key);
 
         /// <summary>
+        /// Unlinks a key.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="key">the key to unlink.</param>
+        /// <returns>the status.</returns>
+        public static async Task<string> UnlinkAsync(this IRedisConnection connection, string key) => await connection.ExecuteAsync("UNLINK", key);
+
+        /// <summary>
         /// Unlinks the key and then adds an updated value of it.
         /// </summary>
         /// <param name="connection">The connection to redis.</param>

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -363,5 +363,36 @@ namespace Redis.OM
         /// <param name="key">the key to unlink.</param>
         /// <returns>the status.</returns>
         public static string Unlink(this IRedisConnection connection, string key) => connection.Execute("UNLINK", key);
+
+        /// <summary>
+        /// Unlinks the key and then adds an updated value of it.
+        /// </summary>
+        /// <param name="connection">The connection to redis.</param>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="storageType">The storage type of the value.</param>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        internal static async Task UnlinkAndSet<T>(this IRedisConnection connection, string key, T value, StorageType storageType)
+        {
+            _ = value ?? throw new ArgumentNullException(nameof(value));
+            if (storageType == StorageType.Json)
+            {
+                await connection.CreateAndEvalAsync(nameof(Scripts.UnlinkAndSendJson), new[] { key }, new[] { JsonSerializer.Serialize(value, Options) });
+            }
+            else
+            {
+                var hash = value.BuildHashSet();
+                var args = new List<string>((hash.Keys.Count * 2) + 1);
+                args.Add(hash.Keys.Count.ToString());
+                foreach (var pair in hash)
+                {
+                    args.Add(pair.Key);
+                    args.Add(pair.Value);
+                }
+
+                await connection.CreateAndEvalAsync(nameof(Scripts.UnlinkAndSetHash), new[] { key }, args.ToArray());
+            }
+        }
     }
 }

--- a/src/Redis.OM/Scripts.cs
+++ b/src/Redis.OM/Scripts.cs
@@ -61,6 +61,31 @@ end
 return redis.call('UNLINK',KEYS[1])";
 
         /// <summary>
+        /// Unlinks and sets a key for a Hash model.
+        /// </summary>
+        internal const string UnlinkAndSetHash = @"
+redis.call('UNLINK',KEYS[1])
+local num_fields = ARGV[1]
+local end_index = num_fields * 2 + 1
+local args = {}
+for i = 2, end_index, 2 do
+    args[i-1] = ARGV[i]
+    args[i] = ARGV[i+1]
+end
+redis.call('HSET',KEYS[1],unpack(args))
+return 0
+";
+
+        /// <summary>
+        /// Unlinks a JSON object and sets the key again with a fresh new JSON object.
+        /// </summary>
+        internal const string UnlinkAndSendJson = @"
+redis.call('UNLINK', KEYS[1])
+redis.call('JSON.SET', KEYS[1], '.', ARGV[1])
+return 0
+";
+
+        /// <summary>
         /// The scripts.
         /// </summary>
         internal static readonly Dictionary<string, string> ScriptCollection = new ()
@@ -68,6 +93,8 @@ return redis.call('UNLINK',KEYS[1])";
             { nameof(JsonDiffResolution), JsonDiffResolution },
             { nameof(HashDiffResolution), HashDiffResolution },
             { nameof(Unlink), Unlink },
+            { nameof(UnlinkAndSetHash), UnlinkAndSetHash },
+            { nameof(UnlinkAndSendJson), UnlinkAndSendJson },
         };
 
         /// <summary>

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -75,5 +75,12 @@ namespace Redis.OM.Searching
         /// <param name="item">The item to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task Update(T item);
+
+        /// <summary>
+        /// Deletes the item from Redis.
+        /// </summary>
+        /// <param name="item">The item to be deleted.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task Delete(T item);
     }
 }

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -68,5 +68,12 @@ namespace Redis.OM.Searching
         /// <param name="expression">the expression to be matched.</param>
         /// <returns>Whether anything matching the expression was found.</returns>
         bool Any(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
+        /// </summary>
+        /// <param name="item">The item to update.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task Update(T item);
     }
 }

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -157,7 +157,6 @@ namespace Redis.OM.Searching
         public async ValueTask SaveAsync()
         {
             var diff = StateManager.DetectDifferences();
-            Console.WriteLine(diff);
             var tasks = new List<Task<int?>>();
             foreach (var item in diff)
             {

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -84,6 +84,35 @@ namespace Redis.OM.Searching
             return res.Documents.Values.Any();
         }
 
+        /// <inheritdoc />
+        public async Task Update(T item)
+        {
+            var key = item.GetKey();
+            IList<IObjectDiff>? diff;
+            var diffConstructed = StateManager.TryDetectDifferencesSingle(key, item, out diff);
+            if (diffConstructed)
+            {
+                if (diff!.Any())
+                {
+                    var args = new List<string>();
+                    var scriptName = diff!.First().Script;
+                    foreach (var update in diff!)
+                    {
+                        args.AddRange(update.SerializeScriptArgs());
+                    }
+
+                    await _connection.CreateAndEvalAsync(scriptName, new[] { key }, args.ToArray());
+                }
+            }
+            else
+            {
+                await _connection.UnlinkAndSet(key, item, StateManager.DocumentAttribute.StorageType);
+            }
+
+            StateManager.InsertIntoSnapshot(key, item);
+            StateManager.InsertIntoData(key, item);
+        }
+
         /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator()
         {

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -113,6 +113,14 @@ namespace Redis.OM.Searching
             StateManager.InsertIntoData(key, item);
         }
 
+        /// <inheritdoc />
+        public async Task Delete(T item)
+        {
+            var key = item.GetKey();
+            await _connection.UnlinkAsync(key);
+            StateManager.Remove(key);
+        }
+
         /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator()
         {

--- a/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
+++ b/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
@@ -182,7 +182,7 @@ namespace Redis.OM.Searching
                     continue;
                 }
 
-                _stateManager.Data.Add(record.Key, record.Value);
+                _stateManager.InsertIntoData(record.Key, record.Value);
                 _stateManager.InsertIntoSnapshot(record.Key, record.Value);
             }
         }

--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -210,9 +210,9 @@ namespace Redis.OM.Searching
             switch (methodCall.Method.Name)
             {
                 case "FirstOrDefault":
-                    return ExecuteQuery<TResult>(expression).Documents.Values.FirstOrDefault() ?? default(TResult);
+                    return FirstOrDefault<TResult>(expression);
                 case "First":
-                    return ExecuteQuery<TResult>(expression).Documents.Values.First();
+                    return First<TResult>(expression);
                 case "Sum":
                 case "Min":
                 case "Max":
@@ -225,6 +225,30 @@ namespace Redis.OM.Searching
             }
 
             throw new NotImplementedException();
+        }
+
+        private TResult? First<TResult>(Expression expression)
+            where TResult : notnull
+        {
+            var res = ExecuteQuery<TResult>(expression).Documents.First();
+            StateManager.InsertIntoData(res.Key, res.Value);
+            StateManager.InsertIntoSnapshot(res.Key, res.Value);
+            return res.Value;
+        }
+
+        private TResult? FirstOrDefault<TResult>(Expression expression)
+            where TResult : notnull
+        {
+            var res = ExecuteQuery<TResult>(expression);
+            if (res.Documents.Any())
+            {
+                var kvp = res.Documents.FirstOrDefault();
+                StateManager.InsertIntoSnapshot(kvp.Key, kvp.Value);
+                StateManager.InsertIntoData(kvp.Key, kvp.Value);
+                return kvp.Value;
+            }
+
+            return default;
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/Person.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/Person.cs
@@ -8,6 +8,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
     public partial class Person
     {
         [RedisIdField]
+        [Indexed]
         public string Id { get; set; }
 
         public Person Mother { get; set; }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -260,5 +260,63 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal("Steve", reconstituded.Name);
             Assert.Equal(new GeoLoc(1.0,1.0), reconstituded.Home);
         }
+
+        [Fact]
+        public async Task TestUpdate()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var testP = new Person {Name = "Steve", Age = 32};
+            var key = await collection.InsertAsync(testP);
+            var queriedP = await collection.FindByIdAsync(key);
+            Assert.NotNull(queriedP);
+            queriedP.Age = 33;
+            await collection.Update(queriedP);
+
+            var secondQueriedP = await collection.FindByIdAsync(key);
+            
+            Assert.NotNull(secondQueriedP);
+            Assert.Equal(33, secondQueriedP.Age);
+            Assert.Equal(secondQueriedP.Id, queriedP.Id);
+            Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
+
+        [Fact]
+        public async Task TestUpdateName()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var testP = new Person {Name = "Steve", Age = 32};
+            var key = await collection.InsertAsync(testP);
+            var id = testP.Id;
+            var queriedP = collection.First(x => x.Id == id);
+            Assert.NotNull(queriedP);
+            queriedP.Name = "Bob";
+            await collection.Update(queriedP);
+
+            var secondQueriedP = await collection.FindByIdAsync(key);
+            
+            Assert.NotNull(secondQueriedP);
+            Assert.Equal("Bob", secondQueriedP.Name);
+            Assert.Equal(secondQueriedP.Id, queriedP.Id);
+            Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
+
+        [Fact]
+        public async Task TestUpdateHashPerson()
+        {
+            var collection = new RedisCollection<HashPerson>(_connection);
+            var testP = new HashPerson {Name = "Steve", Age = 32};
+            var key = await collection.InsertAsync(testP);
+            var queriedP = await collection.FindByIdAsync(key);
+            Assert.NotNull(queriedP);
+            queriedP.Age = 33;
+            await collection.Update(queriedP);
+
+            var secondQueriedP = await collection.FindByIdAsync(key);
+            
+            Assert.NotNull(secondQueriedP);
+            Assert.Equal(33, secondQueriedP.Age);
+            Assert.Equal(secondQueriedP.Id, queriedP.Id);
+            Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -3,6 +3,7 @@ using Moq.Language.Flow;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Redis.OM;
 using Redis.OM.Contracts;
 using Redis.OM.Searching;
@@ -16,11 +17,11 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         RedisReply _mockReply = new RedisReply[]
         {
             new RedisReply(1),
-            new RedisReply("Person:33b58265-2656-4c5e-8476-7246549797d1"),
+            new RedisReply("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
             new RedisReply(new RedisReply[]
             {
                 "$",
-                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71}"
+                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
             })
         };
 
@@ -497,6 +498,74 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "50",
                 "km"
             ));
+        }
+
+        [Fact]
+        public async Task TestUpdateJson()
+        {
+            _mock.Setup(x=>x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Age = 33;
+            await collection.Update(steve);
+            _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33"));
+            Scripts.ShaCollection.Clear();
+        }
+
+        [Fact]
+        public async Task TestUpdateJsonName()
+        {
+            _mock.Setup(x=>x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Name = "Bob";
+            await collection.Update(steve);
+            _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Name","\"Bob\""));
+            Scripts.ShaCollection.Clear();
+        }
+
+        [Fact]
+        public async Task TestUpdateJsonNestedObject()
+        {
+            _mock.Setup(x=>x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Address = new Address {State = "Florida"};
+            await collection.Update(steve);
+            var expected = "{\r\n  \"State\": \"Florida\"\r\n}";
+            _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address",expected));
+
+            steve.Address.City = "Satellite Beach";
+            await collection.Update(steve);
+            expected = "\"Satellite Beach\"";
+            _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address.City",expected));
+            
+            Scripts.ShaCollection.Clear();
+        }
+
+        [Fact]
+        public async Task TestUpdateJsonWithDouble()
+        {
+            _mock.Setup(x=>x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Age = 33;
+            steve.Height = 71.5;
+            await collection.Update(steve);
+            _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33", "SET","$.Height", "71.5"));
+            Scripts.ShaCollection.Clear();
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -567,5 +567,22 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33", "SET","$.Height", "71.5"));
             Scripts.ShaCollection.Clear();
         }
+
+        [Fact]
+        public async Task TestDelete()
+        {
+            const string key = "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N";
+            _mock.Setup(x=>x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("UNLINK", It.IsAny<string[]>())).ReturnsAsync("1");
+            var colleciton = new RedisCollection<Person>(_mock.Object);
+            var steve = colleciton.First(x => x.Name == "Steve");
+            Assert.True(colleciton.StateManager.Data.ContainsKey(key));
+            Assert.True(colleciton.StateManager.Snapshot.ContainsKey(key));
+            await colleciton.Delete(steve);
+            _mock.Verify(x=>x.ExecuteAsync("UNLINK",key));
+            Assert.False(colleciton.StateManager.Data.ContainsKey(key));
+            Assert.False(colleciton.StateManager.Snapshot.ContainsKey(key));
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -541,7 +541,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = collection.First(x => x.Name == "Steve");
             steve.Address = new Address {State = "Florida"};
             await collection.Update(steve);
-            var expected = "{\r\n  \"State\": \"Florida\"\r\n}";
+            var expected = $"{{{Environment.NewLine}  \"State\": \"Florida\"{Environment.NewLine}}}";
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address",expected));
 
             steve.Address.City = "Satellite Beach";


### PR DESCRIPTION
Adds an API to update / delete a single record at a time.

Flow for update:

case 1: the snapshot contains the record
* Compute diff between what's in the snapshot and the record
* Run script to bring the records into sync
case 2: Snapshot does not contain the record
* Run script to unlink the object, and then set the whole record.

For delete, simply find the keyname from the object and unlink it.