### PR TITLE
Fixing empty redis collection count bug

### DIFF
--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ClassForEmptyRedisCollection.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ClassForEmptyRedisCollection.cs
@@ -1,0 +1,10 @@
+﻿using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    [Document(IndexName = "empty-index")]
+    public class ClassForEmptyRedisCollection
+    {
+        [Indexed] public string TagField { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -260,5 +260,13 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal("Steve", reconstituded.Name);
             Assert.Equal(new GeoLoc(1.0,1.0), reconstituded.Home);
         }
+
+        [Fact]
+        public void TestCountWithEmptyCollection()
+        {
+            var collection = new RedisCollection<ClassForEmptyRedisCollection>(_connection);
+            var count = collection.Count();
+            Assert.Equal(0,count);
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RedisSetupCollection.cs
+++ b/test/Redis.OM.Unit.Tests/RedisSetupCollection.cs
@@ -1,5 +1,6 @@
 ﻿using Redis.OM.Contracts;
 using System;
+using Redis.OM.Unit.Tests.RediSearchTests;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -15,7 +16,8 @@ namespace Redis.OM.Unit.Tests
         {
             var personIndexExists = false;
             var hashPersonIndexExists = false;
-
+            var emptyIndexExists = false;
+            
             try
             {
                 Connection.Execute("FT.INFO", "person-idx");
@@ -36,10 +38,23 @@ namespace Redis.OM.Unit.Tests
                 // ignored
             }
 
+            try
+            {
+                Connection.Execute("FT.INFO", "empty-index");
+                emptyIndexExists = true;
+            }
+            catch
+            {
+                //ignored
+            }
+
             if(!personIndexExists)
                 Connection.CreateIndex(typeof(RediSearchTests.Person));
             if (!hashPersonIndexExists)
                 Connection.CreateIndex(typeof(RediSearchTests.HashPerson));
+            if(!emptyIndexExists)
+                Connection.CreateIndex(typeof(ClassForEmptyRedisCollection));
+            
         }
 
         private IRedisConnection _connection = null;


### PR DESCRIPTION
Fixes #67 , When an index has no items added to it yet, when it groups downwards to reduce, it does not actually report a count in the aggregation results, this means when we try to pull it out of the aggregation result, we get an error. We can specifically work around this for the COUNT reduction since the first part of the result is actually the number of matching records, may need to look into this a bit more for other reductions (or perhaps RediSearch will need to address this). 