### PR TITLE
Fixing issues with Model property access, string interpolation

### DIFF
--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -302,6 +302,62 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
         
         [Fact]
+        public void TestBasicQueryFromPropertyOfModel()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var anonObject = new Person() {Name = "Steve"};
+            collection.Where(x => x.Name == anonObject.Name).ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Name:\"Steve\")",
+                "LIMIT",
+                "0",
+                "100"));
+        }
+
+        [Fact]
+        public void TestBasicQueryFromPropertyOfModelWithStringInterpolation()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var anonObject = new Person() {Name = "Steve"};
+            collection.Where(x => x.Name == $"A {nameof(Person)} named {anonObject.Name}").ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Name:\"A Person named Steve\")",
+                "LIMIT",
+                "0",
+                "100"));
+        }
+
+        [Fact]
+        public void TestBasicQueryFromPropertyOfModelWithStringFormatFourArgs()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var anonObject = new Person() {Name = "Steve"};
+            var a = "A";
+            var named = "named";
+            collection.Where(x => x.Name == $"{a} {nameof(Person)} {named} {anonObject.Name}").ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Name:\"A Person named Steve\")",
+                "LIMIT",
+                "0",
+                "100"));
+        }
+
+        [Fact]
         public void TestBasicQueryWithContainsWithNegation()
         {
             _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))                            

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -308,8 +308,8 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 .Returns(_mockReply);
 
             var collection = new RedisCollection<Person>(_mock.Object);
-            var anonObject = new Person() {Name = "Steve"};
-            collection.Where(x => x.Name == anonObject.Name).ToList();
+            var modelObject = new Person() {Name = "Steve"};
+            collection.Where(x => x.Name == modelObject.Name).ToList();
             _mock.Verify(x => x.Execute(
                 "FT.SEARCH",
                 "person-idx",
@@ -326,8 +326,8 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 .Returns(_mockReply);
 
             var collection = new RedisCollection<Person>(_mock.Object);
-            var anonObject = new Person() {Name = "Steve"};
-            collection.Where(x => x.Name == $"A {nameof(Person)} named {anonObject.Name}").ToList();
+            var modelObject = new Person() {Name = "Steve"};
+            collection.Where(x => x.Name == $"A {nameof(Person)} named {modelObject.Name}").ToList();
             _mock.Verify(x => x.Execute(
                 "FT.SEARCH",
                 "person-idx",
@@ -344,10 +344,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 .Returns(_mockReply);
 
             var collection = new RedisCollection<Person>(_mock.Object);
-            var anonObject = new Person() {Name = "Steve"};
+            var modelObject = new Person() {Name = "Steve"};
             var a = "A";
             var named = "named";
-            collection.Where(x => x.Name == $"{a} {nameof(Person)} {named} {anonObject.Name}").ToList();
+            collection.Where(x => x.Name == string.Format("{0} {1} {2} {3}", a, nameof(Person), named, modelObject.Name)).ToList();
             _mock.Verify(x => x.Execute(
                 "FT.SEARCH",
                 "person-idx",


### PR DESCRIPTION
Fixing issue with Model property access within queries, it was formatting the query strings as a path to the property rather than the value. This also removes a nasty Compile operation. 

Added new path for handling string interpolation and string formats.

Fixes issues raised in #84 