### PR TITLE
adding certain async collection operations

### DIFF
--- a/src/Redis.OM/Modeling/DocumentAttributeExtensions.cs
+++ b/src/Redis.OM/Modeling/DocumentAttributeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Redis.OM.Modeling
+{
+    /// <summary>
+    /// utility functions for document attribute class.
+    /// </summary>
+    internal static class DocumentAttributeExtensions
+    {
+        /// <summary>
+        /// Get's the index name for the attribute and type.
+        /// </summary>
+        /// <param name="attr">The document attribute.</param>
+        /// <param name="type">The type.</param>
+        /// <returns>The index name.</returns>
+        internal static string GetIndexName(this DocumentAttribute attr, Type type) => string.IsNullOrEmpty(attr.IndexName) ? $"{type.Name.ToLower()}-idx" : attr.IndexName!;
+    }
+}

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -177,5 +177,17 @@ namespace Redis.OM
             var args = query.SerializeQuery();
             return connection.Execute("FT.SEARCH", args);
         }
+
+        /// <summary>
+        /// Search redis with the given query.
+        /// </summary>
+        /// <param name="connection">the connection to redis.</param>
+        /// <param name="query">the query to use in the search.</param>
+        /// <returns>a Redis reply.</returns>
+        internal static Task<RedisReply> SearchRawResultAsync(this IRedisConnection connection, RedisQuery query)
+        {
+            var args = query.SerializeQuery();
+            return connection.ExecuteAsync("FT.SEARCH", args);
+        }
     }
 }

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -73,27 +73,27 @@ namespace Redis.OM.Searching
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
-        void Update(T item);
+        void UpdateSync(T item);
 
         /// <summary>
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task UpdateAsync(T item);
+        Task Update(T item);
 
         /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
-        void Delete(T item);
+        void DeleteSync(T item);
 
         /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task DeleteAsync(T item);
+        Task Delete(T item);
 
         /// <summary>
         /// Async method for enumerating the collection to a list.

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -82,5 +82,89 @@ namespace Redis.OM.Searching
         /// <param name="item">The item to be deleted.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task Delete(T item);
+
+        /// <summary>
+        /// Async method for enumerating the collection to a list.
+        /// </summary>
+        /// <returns>The enumerated collection as a list.</returns>
+        Task<IList<T>> ToListAsync();
+
+        /// <summary>
+        /// Retrieves the count of the collection async.
+        /// </summary>
+        /// <returns>The Collection's count.</returns>
+        Task<int> CountAsync();
+
+        /// <summary>
+        /// Retrieves the count of the collection async.
+        /// </summary>
+        /// <param name="expression">The predicate match.</param>
+        /// <returns>The Collection's count.</returns>
+        Task<int> CountAsync(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// returns if there's any items in the colleciton.
+        /// </summary>
+        /// <returns>True if there are items present.</returns>
+        Task<bool> AnyAsync();
+
+        /// <summary>
+        /// returns if there's any items in the colleciton.
+        /// </summary>
+        /// <returns>True if there are items present.</returns>
+        /// <param name="expression">The predicate match.</param>
+        Task<bool> AnyAsync(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Returns the first item asynchronously.
+        /// </summary>
+        /// <returns>First or default result.</returns>
+        Task<T> FirstAsync();
+
+        /// <summary>
+        /// Returns the first item asynchronously.
+        /// </summary>
+        /// <param name="expression">The predicate match.</param>
+        /// <returns>First or default result.</returns>
+        Task<T> FirstAsync(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Returns the first or default asynchronously.
+        /// </summary>
+        /// <returns>First or default result.</returns>
+        Task<T?> FirstOrDefaultAsync();
+
+        /// <summary>
+        /// Returns the first or default asynchronously.
+        /// </summary>
+        /// <param name="expression">The predicate match.</param>
+        /// <returns>First or default result.</returns>
+        Task<T?> FirstOrDefaultAsync(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Returns a single record or throws a <see cref="InvalidOperationException"/> if the sequence is empty or contains more than 1 record.
+        /// </summary>
+        /// <returns>The single instance.</returns>
+        Task<T> SingleAsync();
+
+        /// <summary>
+        /// Returns a single record or throws a <see cref="InvalidOperationException"/> if the sequence is empty or contains more than 1 record.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <returns>The single instance.</returns>
+        Task<T> SingleAsync(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Returns a single record or the default if there are none, or more than 1.
+        /// </summary>
+        /// <returns>The single instance.</returns>
+        Task<T?> SingleOrDefaultAsync();
+
+        /// <summary>
+        /// Returns a single record or the default if there are none, or more than 1.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <returns>The single instance.</returns>
+        Task<T?> SingleOrDefaultAsync(Expression<Func<T, bool>> expression);
     }
 }

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -73,15 +73,27 @@ namespace Redis.OM.Searching
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
+        void Update(T item);
+
+        /// <summary>
+        /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
+        /// </summary>
+        /// <param name="item">The item to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Update(T item);
+        Task UpdateAsync(T item);
+
+        /// <summary>
+        /// Deletes the item from Redis.
+        /// </summary>
+        /// <param name="item">The item to be deleted.</param>
+        void Delete(T item);
 
         /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Delete(T item);
+        Task DeleteAsync(T item);
 
         /// <summary>
         /// Async method for enumerating the collection to a list.

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -87,7 +87,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public void Update(T item)
+        public void UpdateSync(T item)
         {
             var key = item.GetKey();
             IList<IObjectDiff>? diff;
@@ -116,7 +116,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public async Task UpdateAsync(T item)
+        public async Task Update(T item)
         {
             var key = item.GetKey();
             IList<IObjectDiff>? diff;
@@ -145,7 +145,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public void Delete(T item)
+        public void DeleteSync(T item)
         {
             var key = item.GetKey();
             _connection.Unlink(key);
@@ -153,7 +153,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public async Task DeleteAsync(T item)
+        public async Task Delete(T item)
         {
             var key = item.GetKey();
             await _connection.UnlinkAsync(key);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -310,7 +310,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = collection.FindById(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            collection.Update(queriedP);
+            collection.UpdateSync(queriedP);
 
             var secondQueriedP = collection.FindById(key);
             
@@ -329,7 +329,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.UpdateAsync(queriedP);
+            await collection.Update(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -349,7 +349,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = collection.First(x => x.Id == id);
             Assert.NotNull(queriedP);
             queriedP.Name = "Bob";
-            await collection.UpdateAsync(queriedP);
+            await collection.Update(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -368,7 +368,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.UpdateAsync(queriedP);
+            await collection.Update(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -309,7 +309,26 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
       
         [Fact]
-        public async Task TestUpdate()
+        public void TestUpdate()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var testP = new Person {Name = "Steve", Age = 32};
+            var key = collection.Insert(testP);
+            var queriedP = collection.FindById(key);
+            Assert.NotNull(queriedP);
+            queriedP.Age = 33;
+            collection.Update(queriedP);
+
+            var secondQueriedP = collection.FindById(key);
+            
+            Assert.NotNull(secondQueriedP);
+            Assert.Equal(33, secondQueriedP.Age);
+            Assert.Equal(secondQueriedP.Id, queriedP.Id);
+            Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
+        
+        [Fact]
+        public async Task TestUpdateAsync()
         {
             var collection = new RedisCollection<Person>(_connection);
             var testP = new Person {Name = "Steve", Age = 32};
@@ -317,7 +336,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -337,7 +356,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = collection.First(x => x.Id == id);
             Assert.NotNull(queriedP);
             queriedP.Name = "Bob";
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -356,7 +375,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualBasic;
+using Redis.OM.Aggregation;
 using Redis.OM.Contracts;
 using Redis.OM.Modeling;
 using Redis.OM.Searching;
@@ -363,6 +364,48 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(33, secondQueriedP.Age);
             Assert.Equal(secondQueriedP.Id, queriedP.Id);
             Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
+
+        [Fact]
+        public async Task TestToListAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection,10000);
+            var list = await collection.ToListAsync();
+            
+            Assert.Equal(collection.Count(), list.Count);
+        }
+
+        [Fact]
+        public async Task CountAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection, 10000);
+            var count = await collection.CountAsync();
+            Assert.Equal(collection.Count(), count);
+        }
+
+        [Fact]
+        public async Task TestFirstOrDefaultAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection,10000);
+            Assert.NotNull(await collection.FirstOrDefaultAsync());
+        }
+
+        [Fact]
+        public async Task TestAnyAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection,10000);
+            Assert.True(await collection.AnyAsync());
+        }
+
+        [Fact]
+        public async Task TestSingleAsync()
+        {
+            var person = new Person {Name = "foo"};
+            var collection = new RedisCollection<Person>(_connection,10000);
+            await collection.InsertAsync(person);
+            var id = person.Id;
+            var res = await collection.SingleAsync(x => x.Id == id);
+            Assert.Equal("foo",res.Name);
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -757,7 +757,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Age = 33;
-            await collection.UpdateAsync(steve);
+            await collection.Update(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33"));
             Scripts.ShaCollection.Clear();
         }
@@ -772,7 +772,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Name = "Bob";
-            await collection.UpdateAsync(steve);
+            await collection.Update(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Name","\"Bob\""));
             Scripts.ShaCollection.Clear();
         }
@@ -787,12 +787,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Address = new Address {State = "Florida"};
-            await collection.UpdateAsync(steve);
+            await collection.Update(steve);
             var expected = $"{{{Environment.NewLine}  \"State\": \"Florida\"{Environment.NewLine}}}";
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address",expected));
 
             steve.Address.City = "Satellite Beach";
-            await collection.UpdateAsync(steve);
+            await collection.Update(steve);
             expected = "\"Satellite Beach\"";
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address.City",expected));
             
@@ -810,7 +810,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = collection.First(x => x.Name == "Steve");
             steve.Age = 33;
             steve.Height = 71.5;
-            await collection.UpdateAsync(steve);
+            await collection.Update(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33", "SET","$.Height", "71.5"));
             Scripts.ShaCollection.Clear();
         }
@@ -826,7 +826,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = colleciton.First(x => x.Name == "Steve");
             Assert.True(colleciton.StateManager.Data.ContainsKey(key));
             Assert.True(colleciton.StateManager.Snapshot.ContainsKey(key));
-            await colleciton.DeleteAsync(steve);
+            await colleciton.Delete(steve);
             _mock.Verify(x=>x.ExecuteAsync("UNLINK",key));
             Assert.False(colleciton.StateManager.Data.ContainsKey(key));
             Assert.False(colleciton.StateManager.Snapshot.ContainsKey(key));
@@ -843,7 +843,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = colleciton.First(x => x.Name == "Steve");
             Assert.True(colleciton.StateManager.Data.ContainsKey(key));
             Assert.True(colleciton.StateManager.Snapshot.ContainsKey(key));
-            colleciton.DeleteAsync(steve);
+            colleciton.Delete(steve);
             _mock.Verify(x=>x.ExecuteAsync("UNLINK",key));
             Assert.False(colleciton.StateManager.Data.ContainsKey(key));
             Assert.False(colleciton.StateManager.Snapshot.ContainsKey(key));


### PR DESCRIPTION
Should resolve #85 

Adding the following async operations:

* First
* FirstOrDefault
* ToList
* Single
* SingleOrDefault
* Count
* Any

As there is some meaningful value to add within the RedisCollection to streamline these queries operationally. Some others are intentionally excluded, e.g. Last, which is not practical to get at without more than 1 round trip to Redis.

Adding `UpdateSync` and `DeleteSync` so there is a sync API for update & delete.