### PR TITLE
Adding multiple-sort support, fixing apply expansion issue.

### DIFF
--- a/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
@@ -36,11 +36,16 @@ namespace Redis.OM.Aggregation.AggregationPredicates
         /// </summary>
         public int? Max { get; set; }
 
+        /// <summary>
+        /// gets the number of arguments of this predicate.
+        /// </summary>
+        internal int NumArgs => Max.HasValue ? 4 : 2;
+
         /// <inheritdoc/>
         public IEnumerable<string> Serialize()
         {
             var numArgs = Max.HasValue ? 4 : 2;
-            var ret = new List<string> { "SORTBY", numArgs.ToString(), $"@{Property}", Direction == SortDirection.Ascending ? "ASC" : "DESC" };
+            var ret = new List<string> { "SORTBY", NumArgs.ToString(), $"@{Property}", Direction == SortDirection.Ascending ? "ASC" : "DESC" };
             if (Max.HasValue)
             {
                 ret.Add("MAX");

--- a/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/AggregateSortBy.cs
@@ -44,7 +44,6 @@ namespace Redis.OM.Aggregation.AggregationPredicates
         /// <inheritdoc/>
         public IEnumerable<string> Serialize()
         {
-            var numArgs = Max.HasValue ? 4 : 2;
             var ret = new List<string> { "SORTBY", NumArgs.ToString(), $"@{Property}", Direction == SortDirection.Ascending ? "ASC" : "DESC" };
             if (Max.HasValue)
             {

--- a/src/Redis.OM/Aggregation/AggregationPredicates/MultiSort.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/MultiSort.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Redis.OM.Aggregation.AggregationPredicates
+{
+    /// <summary>
+    /// Allows a grouping together of multiple sortby predicates.
+    /// </summary>
+    public class MultiSort : IAggregationPredicate
+    {
+        private readonly Stack<AggregateSortBy> _subPredicates = new Stack<AggregateSortBy>();
+
+        /// <summary>
+        /// Inserts a predicate into the multi-sort.
+        /// </summary>
+        /// <param name="sb">The sortby predicate.</param>
+        public void InsertPredicate(AggregateSortBy sb)
+        {
+            _subPredicates.Push(sb);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> Serialize()
+        {
+            var numArgs = _subPredicates.Sum(x => x.NumArgs);
+            List<string> args = new List<string>(numArgs) { "SORTBY", numArgs.ToString() };
+            foreach (var predicate in _subPredicates)
+            {
+                args.AddRange(predicate.Serialize().Skip(2));
+            }
+
+            return args;
+        }
+    }
+}

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -117,7 +117,7 @@ namespace Redis.OM.Common
 
                 operationStack.Push(right);
                 operationStack.Push(GetOperatorFromNodeType(expression.NodeType));
-                if (!string.IsNullOrEmpty(left))
+                if (!string.IsNullOrEmpty(left) && !(expression.Left is BinaryExpression))
                 {
                     operationStack.Push(left);
                 }

--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -100,10 +100,10 @@ namespace Redis.OM.Common
                         TranslateAndPushReductionPredicate(exp, ReduceFunction.MAX, aggregation.Predicates);
                         break;
                     case "OrderBy":
-                        aggregation.Predicates.Push(TranslateSortBy(exp, SortDirection.Ascending));
+                        PushAggregateSortBy(exp, SortDirection.Ascending, aggregation.Predicates);
                         break;
                     case "OrderByDescending":
-                        aggregation.Predicates.Push(TranslateSortBy(exp, SortDirection.Descending));
+                        PushAggregateSortBy(exp, SortDirection.Descending, aggregation.Predicates);
                         break;
                     case "Take":
                         if (aggregation.Limit != null)
@@ -383,6 +383,21 @@ namespace Redis.OM.Common
             var alias = ((ConstantExpression)exp.Arguments[2]).Value.ToString();
             var lambda = (LambdaExpression)((UnaryExpression)exp.Arguments[1]).Operand;
             return new Apply(lambda.Body, alias);
+        }
+
+        private static void PushAggregateSortBy(MethodCallExpression expression, SortDirection dir, Stack<IAggregationPredicate> operationStack)
+        {
+            var sb = TranslateSortBy(expression, dir);
+            if (operationStack.Any() && operationStack.Peek() is MultiSort ms)
+            {
+                ms.InsertPredicate(sb);
+            }
+            else
+            {
+                ms = new MultiSort();
+                ms.InsertPredicate(sb);
+                operationStack.Push(ms);
+            }
         }
 
         private static AggregateSortBy TranslateSortBy(MethodCallExpression expression, SortDirection dir)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -364,5 +364,15 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 Assert.Equal("blah", item[$"FakeResult"]);
             }
         }
+
+        [Fact]
+        public void TestMultipleOrderBys()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.OrderBy(x => x.RecordShell.Name).OrderByDescending(x => x.RecordShell.Age).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "SORTBY", "4", "@Name", "ASC", "@Age", "DESC", "WITHCURSOR", "COUNT", "10000"));
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
@@ -1149,5 +1149,28 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             Assert.Equal("Blah", res[0]["FakeResult"]);
         }
+        
+        [Fact]
+        public void TestMultipleOperations()
+        {
+            var expectedPredicate = "@Age + 5 - 6";
+            _mock.Setup(x => x.Execute(It.IsAny<string>(),
+                    It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisAggregationSet<Person>(_mock.Object);
+            var res = collection.Apply(
+                x=>x.RecordShell.Age + 5 - 6, "res").ToArray();
+
+            _mock.Verify(x => x.Execute(
+                    "FT.AGGREGATE",
+                    "person-idx",
+                    "*",
+                    "APPLY",
+                    expectedPredicate,
+                    "AS",
+                    "res"));
+            Assert.Equal("Blah", res[0]["FakeResult"]);
+        }
+        
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ApplyFunctionTests.cs
@@ -1169,7 +1169,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                     expectedPredicate,
                     "AS",
                     "res"));
-            Assert.Equal("Blah", res[0]["FakeResult"]);
         }
         
     }


### PR DESCRIPTION
This should address #113 - adds multiple-sort predicate support e.g.

`collection.OrderBy(x => x.RecordShell.Name).OrderByDescending(x => x.RecordShell.Age)`

should translate to 

`Execute("FT.AGGREGATE","person-idx", "*", "SORTBY", "4", "@Name", "ASC", "@Age", "DESC", "WITHCURSOR", "COUNT", "10000")`

Also addresses an apply expression expansion issue I stumbled over while investigating #114 