### PR TITLE
Aggregation Load subcommand

### DIFF
--- a/src/Redis.OM/Aggregation/AggregationPredicates/Load.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/Load.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Redis.OM.Aggregation.AggregationPredicates
+{
+    /// <summary>
+    /// Represents a Load aggregation predicate.
+    /// </summary>
+    public class Load : IAggregationPredicate
+    {
+        private const string LoadString = "LOAD";
+        private IEnumerable<string> _properties;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Load"/> class.
+        /// </summary>
+        /// <param name="properties">The properties to load.</param>
+        public Load(IEnumerable<string> properties)
+        {
+            _properties = properties;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> Serialize()
+        {
+            yield return LoadString;
+            yield return _properties.Count().ToString();
+            foreach (var property in _properties)
+            {
+                yield return property;
+            }
+        }
+    }
+}

--- a/src/Redis.OM/Aggregation/AggregationPredicates/LoadAll.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/LoadAll.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Redis.OM.Aggregation.AggregationPredicates
+{
+    /// <summary>
+    /// Represents an aggregation predicate to load all properties of a model.
+    /// </summary>
+    public class LoadAll : IAggregationPredicate
+    {
+        private const string LoadString = "LOAD";
+        private const string Star = "*";
+
+        /// <inheritdoc />
+        public IEnumerable<string> Serialize()
+        {
+            yield return LoadString;
+            yield return Star;
+        }
+    }
+}

--- a/src/Redis.OM/Aggregation/AggregationResult.cs
+++ b/src/Redis.OM/Aggregation/AggregationResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Redis.OM;
 
 namespace Redis.OM.Aggregation
@@ -44,6 +45,13 @@ namespace Redis.OM.Aggregation
         /// </summary>
         /// <param name="key">the aggregation alias.</param>
         public RedisReply this[string key] => Aggregations[key];
+
+        /// <summary>
+        /// Hydrates the record from the available properties. Basically, this will place all the properties found in "Aggregations"
+        /// into an instance of your model, and in the special case where you've called a LoadAll on a JSON model, this should parse the entire record.
+        /// </summary>
+        /// <returns>An instance of the base class hydrated as much as possible by the Results of the aggregation.</returns>
+        public T Hydrate() => RedisObjectHandler.FromHashSet<T>(Aggregations);
 
         /// <summary>
         /// Initializes a set of aggregations from an aggregation result.

--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -569,6 +569,70 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Loads the provided property or properties regardless of whether or not they are set up as Aggregatable in Redis.
+        /// </summary>
+        /// <param name="source">The source.</param>
+        /// <param name="expression">The field expression to use for the load.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <typeparam name="TLoadType">The Type to instruct redis to load.</typeparam>
+        /// <returns>A RedisAggregationSet.</returns>
+        public static RedisAggregationSet<T> Load<T, TLoadType>(this RedisAggregationSet<T> source, Expression<Func<AggregationResult<T>, TLoadType>> expression)
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(Load, source, expression),
+                new[] { source.Expression, Expression.Quote(expression) });
+            return new RedisAggregationSet<T>(source, exp);
+        }
+
+        /// <summary>
+        /// Loads all indexed attributes in a document into the Aggregation pipeline.
+        /// </summary>
+        /// <param name="source">The source set.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <returns>A RedisAggregationSet.</returns>
+        public static RedisAggregationSet<T> LoadAll<T>(this RedisAggregationSet<T> source)
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(LoadAll, source),
+                source.Expression);
+            return new RedisAggregationSet<T>(source, exp);
+        }
+
+        /// <summary>
+        /// Loads the provided property or properties regardless of whether or not they are set up as Aggregatable in Redis.
+        /// </summary>
+        /// <param name="source">The source.</param>
+        /// <param name="expression">The field expression to use for the load.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <typeparam name="TLoadType">The Type to instruct redis to load.</typeparam>
+        /// <returns>A GroupedAggregationSet.</returns>
+        public static GroupedAggregationSet<T> Load<T, TLoadType>(this GroupedAggregationSet<T> source, Expression<Func<AggregationResult<T>, TLoadType>> expression)
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(Load, source, expression),
+                new[] { source.Expression, Expression.Quote(expression) });
+            return new GroupedAggregationSet<T>(source, exp);
+        }
+
+        /// <summary>
+        /// Loads all indexed attributes in a document into the Aggregation pipeline.
+        /// </summary>
+        /// <param name="source">The source set.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <returns>A RedisAggregationSet.</returns>
+        public static GroupedAggregationSet<T> LoadAll<T>(this GroupedAggregationSet<T> source)
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(LoadAll, source),
+                source.Expression);
+            return new GroupedAggregationSet<T>(source, exp);
+        }
+
+        /// <summary>
         /// Group like records together by provided fields.
         /// </summary>
         /// <param name="source">The source.</param>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationFunctionalTests.cs
@@ -78,7 +78,29 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 SalesAdjustment = .8,
                 Height = 13,
                 DepartmentNumber = 1
-            };            
+            };
+            
+            var hashWaldorf = new HashPerson
+            {
+                Name = "Waldorf",
+                Email = "Waldorf@muppets.com",
+                Age = 78,
+                Sales = 750000,
+                SalesAdjustment = .8,
+                Height = 13,
+                DepartmentNumber = 4
+            };
+
+            var hashKermit = new HashPerson
+            {
+                Name = "Kermit the Frog",
+                Email = "kermit@muppets.com",
+                Age = 52,
+                Sales = 1500000,
+                SalesAdjustment = .8,
+                Height = 13,
+                DepartmentNumber = 1
+            };
 
             _connection.Set(kermit);
             _connection.Set(waldorf);
@@ -86,6 +108,8 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _connection.Set(fozzie);
             _connection.Set(beaker);
             _connection.Set(bunsen);
+            _connection.Set(hashKermit);
+            _connection.Set(hashWaldorf);
         }
 
         [Fact]
@@ -147,6 +171,63 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                     .AverageAsync(x => x["AdjustedSales"]);
                 Assert.Equal(527500, average);
             }).GetAwaiter().GetResult();
+        }
+
+        [Fact]
+        public async Task TestLoad()
+        {
+            Setup();
+            var collection = new RedisAggregationSet<Person>(_connection);
+            await foreach (var result in collection.Load(x => x.RecordShell.Name))
+            {
+                Assert.False(string.IsNullOrEmpty(result["Name"]));
+            }
+        }
+        
+        [Fact]
+        public async Task TestLoadAll()
+        {
+            Setup();
+            var collection = new RedisAggregationSet<Person>(_connection);
+            await foreach (var result in collection.LoadAll())
+            {
+                Assert.NotNull(result.Hydrate().Name);
+            }
+        }
+
+        [Fact]
+        public async Task TestPartialHydration()
+        {
+            Setup();
+            var collection = new RedisAggregationSet<Person>(_connection);
+            await foreach (var result in collection.Apply(x => x.RecordShell.Sales * x.RecordShell.SalesAdjustment, "AdjustedSales"))
+            {
+                var partialHydration = result.Hydrate();
+                Assert.True(partialHydration.Sales > 0);
+                Assert.True(partialHydration.SalesAdjustment > 0);
+            }
+        }
+
+        [Fact]
+        public async Task TestHydrateHash()
+        {
+            Setup();
+            var collection = new RedisAggregationSet<HashPerson>(_connection);
+            await foreach (var result in collection.LoadAll())
+            {
+                Assert.NotNull(result.Hydrate().Name);
+            }
+        }
+
+        [Fact]
+        public async Task TestPartialHydrationHash()
+        {
+            Setup();
+            var collection = new RedisAggregationSet<HashPerson>(_connection);
+            await foreach (var result in collection.Load(x=>x.RecordShell.Email))
+            {
+                Assert.NotNull(result.Hydrate().Email);
+            }
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -364,5 +364,35 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 Assert.Equal("blah", item[$"FakeResult"]);
             }
         }
+
+        [Fact]
+        public void TestLoad()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            collection.Load(x => x.RecordShell.Name).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx","*","LOAD","1","Name","WITHCURSOR", "COUNT","10000"));
+        }
+        
+        [Fact]
+        public void TestMultiVariant()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            collection.Load(x => new {x.RecordShell.Name, x.RecordShell.Age}).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx","*","LOAD","2","Name", "Age","WITHCURSOR", "COUNT","10000"));
+        }
+        
+        [Fact]
+        public void TestLoadAll()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            collection.LoadAll().ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx","*","LOAD","*", "WITHCURSOR", "COUNT","10000"));
+        }
     }
 }


### PR DESCRIPTION
I've seen a number of instances to date where a lack of Load functionality in the AggregationSet has caused some heartache where folks have not been able to get stuff loaded in their pipelines. This adds that functionality, as well as providing you the ability to hydrate an object from an aggregation result. There are two new methods `Load` and `LoadAll`. Load allows you to load in a similar manner to how GroupBy expressions work (either a single field or new up an anonymous object with what you're looking for). And LoadAll will just throw a `LOAD *` expression in and that will pull back the entire object (I believe it calls an `HGETALL key` or a `JSON.GET key $` under the hood.