### PR TITLE
hash parsing issue

### DIFF
--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -348,14 +348,29 @@ namespace Redis.OM
 
                 if (type == typeof(bool) || type == typeof(bool?))
                 {
+                    if (!hash.ContainsKey(propertyName))
+                    {
+                        continue;
+                    }
+
                     ret += $"\"{propertyName}\":{hash[propertyName].ToLower()},";
                 }
                 else if (type.IsPrimitive || type == typeof(decimal))
                 {
+                    if (!hash.ContainsKey(propertyName))
+                    {
+                        continue;
+                    }
+
                     ret += $"\"{propertyName}\":{hash[propertyName]},";
                 }
                 else if (type == typeof(string) || type == typeof(GeoLoc) || type == typeof(DateTime) || type == typeof(DateTime?) || type == typeof(DateTimeOffset))
                 {
+                    if (!hash.ContainsKey(propertyName))
+                    {
+                        continue;
+                    }
+
                     ret += $"\"{propertyName}\":\"{hash[propertyName]}\",";
                 }
                 else if (type.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>)))

--- a/test/Redis.OM.Unit.Tests/Serialization/HashObjectWithTwoPropertiesWithMatchingPrefixes.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/HashObjectWithTwoPropertiesWithMatchingPrefixes.cs
@@ -1,0 +1,14 @@
+﻿using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests
+{
+    [Document(IndexName = "employees_idx", StorageType = StorageType.Hash)]
+    public class HashObjectWithTwoPropertiesWithMatchingPrefixes
+    {
+        [Searchable(Sortable = true)] public string Name { get; set; }
+    
+        [Searchable(Aggregatable = true)] public string Location { get; set; }
+    
+        [Searchable(Aggregatable = true)] public int? LocationNumber { get; set; }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/SerializationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Redis.OM.Contracts;
 using Redis.OM.Modeling;
+using Redis.OM.Unit.Tests.RediSearchTests;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -98,6 +99,19 @@ namespace Redis.OM.Unit.Tests
             var guid = Guid.Parse(id.Split(":")[1]);
             Assert.NotEqual(default, guid);
             Assert.NotEqual(default, obj.Id);
+        }
+
+        [Fact]
+        public void TestTwoMatchingPrefixObjects()
+        {
+            var obj = new HashObjectWithTwoPropertiesWithMatchingPrefixes
+            {
+                Name = "Bob",
+                LocationNumber = 10
+            };
+
+            var id = _connection.Set(obj);
+            _connection.Get<HashObjectWithTwoPropertiesWithMatchingPrefixes>(id);
         }
     }
 }


### PR DESCRIPTION
Fixing issue with hash hydration caused by multiple prefixes matching the property name, this is caused by the way we handle serializing collections within hashes and embedded hashes within hashes, just need to check that the property is in what's reported back from Redis. Fixes #120 