### PR TITLE
delete/update remapping to typical sync/async pattern

### DIFF
--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -73,27 +73,27 @@ namespace Redis.OM.Searching
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
-        void UpdateSync(T item);
+        void Update(T item);
 
         /// <summary>
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Update(T item);
+        Task UpdateAsync(T item);
 
         /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
-        void DeleteSync(T item);
+        void Delete(T item);
 
         /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Delete(T item);
+        Task DeleteAsync(T item);
 
         /// <summary>
         /// Async method for enumerating the collection to a list.

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -87,7 +87,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public void UpdateSync(T item)
+        public void Update(T item)
         {
             var key = item.GetKey();
             IList<IObjectDiff>? diff;
@@ -116,7 +116,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public async Task Update(T item)
+        public async Task UpdateAsync(T item)
         {
             var key = item.GetKey();
             IList<IObjectDiff>? diff;
@@ -145,7 +145,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public void DeleteSync(T item)
+        public void Delete(T item)
         {
             var key = item.GetKey();
             _connection.Unlink(key);
@@ -153,7 +153,7 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
-        public async Task Delete(T item)
+        public async Task DeleteAsync(T item)
         {
             var key = item.GetKey();
             await _connection.UnlinkAsync(key);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -310,7 +310,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = collection.FindById(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            collection.UpdateSync(queriedP);
+            collection.Update(queriedP);
 
             var secondQueriedP = collection.FindById(key);
             
@@ -329,7 +329,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -349,7 +349,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = collection.First(x => x.Id == id);
             Assert.NotNull(queriedP);
             queriedP.Name = "Bob";
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             
@@ -368,7 +368,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var queriedP = await collection.FindByIdAsync(key);
             Assert.NotNull(queriedP);
             queriedP.Age = 33;
-            await collection.Update(queriedP);
+            await collection.UpdateAsync(queriedP);
 
             var secondQueriedP = await collection.FindByIdAsync(key);
             

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -757,7 +757,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Age = 33;
-            await collection.Update(steve);
+            await collection.UpdateAsync(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33"));
             Scripts.ShaCollection.Clear();
         }
@@ -772,7 +772,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Name = "Bob";
-            await collection.Update(steve);
+            await collection.UpdateAsync(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Name","\"Bob\""));
             Scripts.ShaCollection.Clear();
         }
@@ -787,12 +787,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Address = new Address {State = "Florida"};
-            await collection.Update(steve);
+            await collection.UpdateAsync(steve);
             var expected = $"{{{Environment.NewLine}  \"State\": \"Florida\"{Environment.NewLine}}}";
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address",expected));
 
             steve.Address.City = "Satellite Beach";
-            await collection.Update(steve);
+            await collection.UpdateAsync(steve);
             expected = "\"Satellite Beach\"";
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Address.City",expected));
             
@@ -810,7 +810,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = collection.First(x => x.Name == "Steve");
             steve.Age = 33;
             steve.Height = 71.5;
-            await collection.Update(steve);
+            await collection.UpdateAsync(steve);
             _mock.Verify(x=>x.ExecuteAsync("EVALSHA","42","1","Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET","$.Age","33", "SET","$.Height", "71.5"));
             Scripts.ShaCollection.Clear();
         }
@@ -826,7 +826,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = colleciton.First(x => x.Name == "Steve");
             Assert.True(colleciton.StateManager.Data.ContainsKey(key));
             Assert.True(colleciton.StateManager.Snapshot.ContainsKey(key));
-            await colleciton.Delete(steve);
+            await colleciton.DeleteAsync(steve);
             _mock.Verify(x=>x.ExecuteAsync("UNLINK",key));
             Assert.False(colleciton.StateManager.Data.ContainsKey(key));
             Assert.False(colleciton.StateManager.Snapshot.ContainsKey(key));
@@ -843,7 +843,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = colleciton.First(x => x.Name == "Steve");
             Assert.True(colleciton.StateManager.Data.ContainsKey(key));
             Assert.True(colleciton.StateManager.Snapshot.ContainsKey(key));
-            colleciton.Delete(steve);
+            colleciton.DeleteAsync(steve);
             _mock.Verify(x=>x.ExecuteAsync("UNLINK",key));
             Assert.False(colleciton.StateManager.Data.ContainsKey(key));
             Assert.False(colleciton.StateManager.Snapshot.ContainsKey(key));


### PR DESCRIPTION
Original Delete/Update methods were written as purely async with DeleteSync/UpdateSync added as more or less an afterthought, remapping them to be more typical of .NET patterns. Resolves #125, This will be a breaking change, so will need to rev to 0.2.0.