### PR TITLE
fixing issues with async methods

### DIFF
--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -463,6 +463,42 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Orders the collection by the provided attribute.
+        /// </summary>
+        /// <param name="source">The Redis Collection.</param>
+        /// <param name="expression">The expression.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <typeparam name="TField">The field type to order by.</typeparam>
+        /// <returns>A redis collection extending the pipeline of linq expressions with the relevant SORTBY.</returns>
+        public static IRedisCollection<T> OrderBy<T, TField>(this IRedisCollection<T> source, Expression<Func<T, TField>> expression)
+            where T : notnull
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(OrderBy, source, expression),
+                new[] { source.Expression, Expression.Quote(expression) });
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, source.ChunkSize);
+        }
+
+        /// <summary>
+        /// Orders the collection by the provided attribute.
+        /// </summary>
+        /// <param name="source">The Redis Collection.</param>
+        /// <param name="expression">The expression.</param>
+        /// <typeparam name="T">The base type.</typeparam>
+        /// <typeparam name="TField">The field type to order by.</typeparam>
+        /// <returns>A redis collection extending the pipeline of linq expressions with the relevant SORTBY.</returns>
+        public static IRedisCollection<T> OrderByDescending<T, TField>(this IRedisCollection<T> source, Expression<Func<T, TField>> expression)
+            where T : notnull
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(OrderByDescending, source, expression),
+                new[] { source.Expression, Expression.Quote(expression) });
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, source.ChunkSize);
+        }
+
+        /// <summary>
         /// Get a Random sample from redis.
         /// </summary>
         /// <param name="source">The source.</param>

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -175,7 +175,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<int> CountAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 0, Offset = 0 };
             return (int)(await _connection.SearchAsync<T>(query)).DocumentCount;
         }
@@ -183,7 +183,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<int> CountAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 0, Offset = 0 };
             return (int)(await _connection.SearchAsync<T>(query)).DocumentCount;
         }
@@ -191,7 +192,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<bool> AnyAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 0, Offset = 0 };
             return (int)(await _connection.SearchAsync<T>(query)).DocumentCount > 0;
         }
@@ -199,7 +200,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<bool> AnyAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 0, Offset = 0 };
             return (int)(await _connection.SearchAsync<T>(query)).DocumentCount > 0;
         }
@@ -207,7 +209,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T> FirstAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             return res.Documents.Select(x => x.Value).First();
@@ -216,7 +218,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T> FirstAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             return res.Documents.Select(x => x.Value).First();
@@ -225,7 +228,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T?> FirstOrDefaultAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             return res.Documents.Select(x => x.Value).FirstOrDefault();
@@ -234,7 +237,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T?> FirstOrDefaultAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             return res.Documents.Select(x => x.Value).FirstOrDefault();
@@ -243,7 +247,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T> SingleAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             if (res.DocumentCount > 1)
@@ -257,7 +261,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T> SingleAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             if (res.DocumentCount > 1)
@@ -271,7 +276,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T?> SingleOrDefaultAsync()
         {
-            var query = new RedisQuery(StateManager.DocumentAttribute.GetIndexName(typeof(T)));
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             if (res.DocumentCount != 1)
@@ -285,7 +290,8 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task<T?> SingleOrDefaultAsync(Expression<Func<T, bool>> expression)
         {
-            var query = ExpressionTranslator.BuildQueryFromExpression(expression, typeof(T));
+            var exp = Expression.Call(null, GetMethodInfo(this.Where, expression), new[] { Expression, Expression.Quote(expression) });
+            var query = ExpressionTranslator.BuildQueryFromExpression(exp, typeof(T));
             query.Limit = new SearchLimit { Number = 1, Offset = 0 };
             var res = await _connection.SearchAsync<T>(query);
             if (res.DocumentCount != 1)
@@ -389,6 +395,11 @@ namespace Redis.OM.Searching
         {
             var provider = (RedisQueryProvider)Provider;
             return new RedisCollectionEnumerator<T>(Expression, provider.Connection, ChunkSize, StateManager);
+        }
+
+        private static MethodInfo GetMethodInfo<T1, T2>(Func<T1, T2> f, T1 unused)
+        {
+            return f.Method;
         }
 
         private void Initialize(RedisQueryProvider provider, Expression? expression)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -1238,5 +1238,322 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "0"));
         }
+
+        [Fact]
+        public async Task TestOrderByWithAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var expectedPredicate = "*";
+            _ = await collection.OrderBy(x => x.Age).ToListAsync();
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "100",
+                "SORTBY",
+                "Age",
+                "ASC"));
+        }
+
+        [Fact]
+        public async Task TestOrderByDescendingWithAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var expectedPredicate = "*";
+            _ = await collection.OrderByDescending(x => x.Age).ToListAsync();
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "100",
+                "SORTBY",
+                "Age",
+                "DESC"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsWithFirstOrDefaultAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").FirstOrDefaultAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsWithFirstAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").FirstAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsWithAnyAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").AnyAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "0"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsSingleOrDefaultAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").SingleOrDefaultAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsSingleAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").SingleAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1"));
+        }
+
+        [Fact]
+        public async Task CombinedExpressionsCountAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.Where(x => x.Name == "Bob").CountAsync();
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "0"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionFirstOrDefaultAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply2Count);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).FirstOrDefaultAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionFirstAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).FirstAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionAnyAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).AnyAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "0",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionSingleAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).SingleAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionSingleOrDefaultAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).SingleOrDefaultAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "1",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
+        [Fact]
+        public async Task TestCombinedExpressionWithExpressionCountAsync()
+        {
+            _mock.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+
+            var expectedPredicate = "(@Name:\"Bob\")";
+            _ = await collection.GeoFilter(x => x.Home, 5,5,10,GeoLocDistanceUnit.Miles).CountAsync(x=>x.Name == "Bob");
+
+            _mock.Verify(x=>x.ExecuteAsync(
+                "FT.SEARCH",
+                "person-idx",
+                expectedPredicate,
+                "LIMIT",
+                "0",
+                "0",
+                "GEOFILTER",
+                "Home",
+                "5",
+                "5",
+                "10",
+                "mi"));
+        }
+
     }
 }


### PR DESCRIPTION
This fixes a couple of issues that have come up with the advent of the async enumeration methods (Count, Any, First, FirstOrDefault, Single, SingleOrDefault) note: can't properly manage a last at this point.

1. In #103 and #111 - it's been pointed out that OrderBy and OrderByDescending do not have an extension method, this means you have to annoyingly recast the collection back to the interface type if you want to call the Async methods, I've added extension methods for just this issue.
2. In #127 and #93 - There's an issue where an expression is simply ignored when you invoke one of the async methods, this in fact was the case, if you called one of those methods without an expression, it would simply ignore the other expressions in the pipeline. And if you DID provide an expression, it will ONLY honor that expression and not the preceding ones in the pipeline, at the moment we only support one `where` like expression, and while that's unchanged, it ought to properly integrate those other expressions in the pipeline.

This fixes both of these issues 