### PR TITLE
Fixing special char query issue for array contains

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -18,6 +18,15 @@ namespace Redis.OM.Common
     internal static class ExpressionParserUtilities
     {
         /// <summary>
+        /// Characters to escape when serializing a tag expression.
+        /// </summary>
+        private static readonly char[] TagEscapeChars =
+        {
+            ',', '.', '<', '>', '{', '}', '[', ']', '"', '\'', ':', ';',
+            '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '+', '=', '~', '|', ' ',
+        };
+
+        /// <summary>
         /// Get's the operand string.
         /// </summary>
         /// <param name="exp">the expression to parse.</param>
@@ -232,6 +241,27 @@ namespace Redis.OM.Common
             }
 
             return attr;
+        }
+
+        /// <summary>
+        /// Escapes a tag field string.
+        /// </summary>
+        /// <param name="text">the text toe escape.</param>
+        /// <returns>The Escaped Text.</returns>
+        internal static string EscapeTagField(string text)
+        {
+            var sb = new StringBuilder();
+            foreach (var c in text)
+            {
+                if (TagEscapeChars.Contains(c))
+                {
+                    sb.Append("\\");
+                }
+
+                sb.Append(c);
+            }
+
+            return sb.ToString();
         }
 
         private static string GetOperandStringForMember(MemberExpression member)
@@ -554,7 +584,7 @@ namespace Redis.OM.Common
 
             var memberName = GetOperandStringForMember(expression);
             var literal = GetOperandStringForQueryArgs(exp.Arguments.Last());
-            return (type == typeof(string)) ? $"{memberName}:{literal}" : $"{memberName}:{{{literal}}}";
+            return (type == typeof(string)) ? $"{memberName}:{literal}" : $"{memberName}:{{{EscapeTagField(literal)}}}";
         }
     }
 }

--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -18,15 +18,6 @@ namespace Redis.OM.Common
     internal class ExpressionTranslator
     {
         /// <summary>
-        /// Characters to escape when serializing a tag expression.
-        /// </summary>
-        private static readonly char[] TagEscapeChars =
-        {
-            ',', '.', '<', '>', '{', '}', '[', ']', '"', '\'', ':', ';',
-            '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '+', '=', '~', '|', ' ',
-        };
-
-        /// <summary>
         /// Build's an aggregation from an expression.
         /// </summary>
         /// <param name="expression">The expression to translate.</param>
@@ -598,7 +589,7 @@ namespace Redis.OM.Common
             switch (searchFieldType)
             {
                 case SearchFieldType.TAG:
-                    sb.Append($"{{{EscapeTagField(right)}}}");
+                    sb.Append($"{{{ExpressionParserUtilities.EscapeTagField(right)}}}");
                     break;
                 case SearchFieldType.TEXT:
                     sb.Append($"\"{right}\"");
@@ -608,22 +599,6 @@ namespace Redis.OM.Common
                     break;
                 default:
                     throw new InvalidOperationException("Could not translate query, equality searches only supported for Tag and numeric fields");
-            }
-
-            return sb.ToString();
-        }
-
-        private static string EscapeTagField(string text)
-        {
-            var sb = new StringBuilder();
-            foreach (var c in text)
-            {
-                if (TagEscapeChars.Contains(c))
-                {
-                    sb.Append("\\");
-                }
-
-                sb.Append(c);
             }
 
             return sb.ToString();

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -282,6 +282,16 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steve = collection.FirstOrDefault(x => x.NickNames.Contains("Steve"));
             Assert.Equal(id.Split(':')[1], steve.Id);
         }
+
+        [Fact]
+        public void TestArrayQuerySpecialChars()
+        {
+            var testP = new Person{Name = "Stephen", Home = new GeoLoc(1.0, 1.0), Address = new Address{ ForwardingAddress = new Address{City = "Newark"}}, NickNames = new []{"Steve@redis.com"}};
+            var id = _connection.Set(testP);
+            var collection = new RedisCollection<Person>(_connection);
+            var steve = collection.FirstOrDefault(x => x.NickNames.Contains("Steve@redis.com"));
+            Assert.Equal(id.Split(':')[1], steve.Id);
+        }
         
         [Fact]
         public void TestListQuery()

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -711,6 +711,24 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
         
         [Fact]
+        public void TestArrayContainsSpecialChar()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object, 1000);
+            collection.Where(x => x.NickNames.Contains("Steve@redis.com")).ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "@NickNames:{Steve\\@redis\\.com}",
+                "LIMIT",
+                "0",
+                "1000"
+            ));
+        }
+        
+        [Fact]
         public void TestArrayContainsVar()
         {
             _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))


### PR DESCRIPTION
Need to make sure that when we are doing contains on tag fields that the strings we are checking are properly escaped, fixes #134 