### PR TITLE
multiple enumeration save issue

### DIFF
--- a/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
+++ b/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
@@ -51,6 +51,15 @@ namespace Redis.OM.Modeling
         internal IDictionary<string, object?> Data { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
+        /// Clears out all the data in the state manager at re-enumeration.
+        /// </summary>
+        internal void Clear()
+        {
+            Snapshot.Clear();
+            Data.Clear();
+        }
+
+        /// <summary>
         /// Removes the key from the data and snapshot.
         /// </summary>
         /// <param name="key">The key to remove.</param>

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -299,6 +299,7 @@ namespace Redis.OM.Searching
         /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator()
         {
+            StateManager.Clear();
             return new RedisCollectionEnumerator<T>(Expression, _connection, ChunkSize, StateManager);
         }
 
@@ -388,6 +389,7 @@ namespace Redis.OM.Searching
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
             var provider = (RedisQueryProvider)Provider;
+            StateManager.Clear();
             return new RedisCollectionEnumerator<T>(Expression, provider.Connection, ChunkSize, StateManager);
         }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -159,26 +159,41 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var steves = collection.Where(x => x.Name == "Steve");
             Assert.Equal(count, steves.Count());
         }
-        
+
         [Fact]
-        public void TestSaveAsync()
+        public async Task TestSaveAsync()
         {
             var collection = new RedisCollection<Person>(_connection);
-            Task.Run(async () =>
+            var count = 0;
+            await foreach (var person in collection.Where(x=>x.Name == "Chris"))
             {
-                var chrises = collection.Where(x=>x.Name == "Chris");
-                var count = chrises.Count();
-                await foreach (var person in chrises)
-                {
-                    person.Name = "Augustine";
-                    person.Mother = new Person {Name = "Monica"};
-                }
-                await collection.SaveAsync();
-                var augustines = collection.Where(x => x.Name == "Augustine");
-                var numSteves = augustines.Count();
-                Assert.Equal(count, augustines.Count());
-            }).GetAwaiter().GetResult();
+                count++;
+                person.Name = "Augustine";
+                person.Mother = new Person {Name = "Monica"};
+            }
+            await collection.SaveAsync();
+            var augustines = collection.Where(x => x.Name == "Augustine");
+            var numSteves = augustines.Count();
+            Assert.Equal(count, augustines.Count());
         }
+        
+        [Fact]
+        public async Task TestSaveAsyncSecondEnumeration()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var count = 0;
+            await collection.Where(x => x.Name == "Chris").ToListAsync();
+            await foreach (var person in collection.Where(x=>x.Name == "Chris"))
+            {
+                count++;
+                person.Name = "Thomas";
+            }
+            await collection.SaveAsync();
+            var augustines = collection.Where(x => x.Name == "Thomas");
+            var numSteves = augustines.Count();
+            Assert.Equal(count, augustines.Count());
+        }
+
         
         [Fact]
         public async Task TestSaveHashAsync()


### PR DESCRIPTION
Fixes #135 - issue is that when you enumerate a RedisCollection multiple times, the pointers move around for the data vs snapshots, so the diff doesn't take quite right, this changes that behavior, now only the last enumeration is honored. And the entire state is cleared out between enumerations.