### PR TITLE
Adding FindByIdsAsync

### DIFF
--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -213,5 +213,13 @@ namespace Redis.OM.Searching
         /// <param name="expression">The expression.</param>
         /// <returns>The single instance.</returns>
         T? SingleOrDefault(Expression<Func<T, bool>> expression);
+
+        /// <summary>
+        /// Retrieves the objects from redis at the given IDs,
+        /// if there is no such Object in Redis, null is returned in the KVP.
+        /// </summary>
+        /// <param name="ids">The Ids to look up.</param>
+        /// <returns>A dictionary correlating the ids provided to the objects in Redis.</returns>
+        Task<IDictionary<string, T?>> FindByIdsAsync(IEnumerable<string> ids);
     }
 }

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -407,6 +407,19 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc/>
+        public async Task<IDictionary<string, T?>> FindByIdsAsync(IEnumerable<string> ids)
+        {
+            var tasks = new Dictionary<string, Task<T?>>();
+            foreach (var id in ids)
+            {
+                tasks.Add(id, FindByIdAsync(id));
+            }
+
+            await Task.WhenAll(tasks.Values);
+            return tasks.ToDictionary(x => x.Key, x => x.Value.Result);
+        }
+
+        /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator()
         {
             StateManager.Clear();

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -630,7 +630,56 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.NotEmpty(results);
             results = await collection.Where(x => x.AddressList.Any(x => x.City == "Satellite Beach")).ToListAsync();
             Assert.NotEmpty(results);
-            
+        }
+
+        [Fact]
+        public async Task FindByIdsAsyncIds()
+        {
+            var person1 = new Person() {Name = "Alice", Age = 51};
+            var person2 = new Person() {Name = "Bob", Age = 37};
+
+            var collection = new RedisCollection<Person>(_connection);
+
+            await collection.InsertAsync(person1);
+            await collection.InsertAsync(person2);
+
+            var ids = new string[] {person1.Id, person2.Id};
+
+            var people = await collection.FindByIdsAsync(ids);
+            Assert.NotNull(people[ids[0]]);
+            Assert.Equal(ids[0], people[ids[0]].Id);
+            Assert.Equal("Alice", people[ids[0]].Name);
+            Assert.Equal(51, people[ids[0]].Age);
+
+            Assert.NotNull(people[ids[1]]);
+            Assert.Equal(ids[1], people[ids[1]].Id);
+            Assert.Equal("Bob", people[ids[1]].Name);
+            Assert.Equal(37, people[ids[1]].Age);
+        }
+
+        [Fact]
+        public async Task FindByIdsAsyncKeys()
+        {
+            var person1 = new Person() {Name = "Alice", Age = 51};
+            var person2 = new Person() {Name = "Bob", Age = 37};
+
+            var collection = new RedisCollection<Person>(_connection);
+
+            var key1 = await collection.InsertAsync(person1);
+            var key2 = await collection.InsertAsync(person2);
+
+            var keys = new string[] {key1, key2};
+
+            var people = await collection.FindByIdsAsync(keys);
+            Assert.NotNull(people[keys[0]]);
+            Assert.Equal(keys[0].Split(':').Last(), people[keys[0]]!.Id);
+            Assert.Equal("Alice", people[keys[0]].Name);
+            Assert.Equal(51, people[keys[0]].Age);
+
+            Assert.NotNull(people[keys[1]]);
+            Assert.Equal(keys[1].Split(':').Last(), people[keys[1]]!.Id);
+            Assert.Equal("Bob", people[keys[1]].Name);
+            Assert.Equal(37, people[keys[1]].Age);
         }
     }
 }


### PR DESCRIPTION
Adds FindByIdAsync, solves #96 - explicitly does not add a non-async version due to pipelining concerns.