### PR TITLE
Update Test Project to .NET 6

### DIFF
--- a/docker/dotnet/dockerfile
+++ b/docker/dotnet/dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /app
 ADD . /app

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 
 WORKDIR /app

--- a/test/Redis.OM.Test.AspDotnetCore/Redis.OM.Test.AspDotnetCore.csproj
+++ b/test/Redis.OM.Test.AspDotnetCore/Redis.OM.Test.AspDotnetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Redis.Developer.Test.AspDotnetCore</RootNamespace>
     </PropertyGroup>
 

--- a/test/Redis.OM.Test.ConsoleApp/Redis.OM.Test.ConsoleApp.csproj
+++ b/test/Redis.OM.Test.ConsoleApp/Redis.OM.Test.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Redis.OM.Test.ConsoleApp</RootNamespace>
   </PropertyGroup>
 

--- a/test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj
+++ b/test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />    
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since .NET is already [out of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle), how about upgrading the test project to use .NET 6?

Feel free to give any feedback about these changes.