### PR TITLE
allows users to not save enumerated data in the StateManager

### DIFF
--- a/src/Redis.OM/RedisConnectionProvider.cs
+++ b/src/Redis.OM/RedisConnectionProvider.cs
@@ -70,5 +70,15 @@ namespace Redis.OM
         /// <returns>A RedisCollection.</returns>
         public IRedisCollection<T> RedisCollection<T>(int chunkSize = 100)
             where T : notnull => new RedisCollection<T>(Connection, chunkSize);
+
+        /// <summary>
+        /// Gets a redis collection.
+        /// </summary>
+        /// <typeparam name="T">The type the collection will be retrieving.</typeparam>
+        /// <param name="saveState">Whether or not the RedisCollection should maintain the state of documents it enumerates.</param>
+        /// <param name="chunkSize">Size of chunks to use during pagination, larger chunks = larger payloads returned but fewer round trips.</param>
+        /// <returns>A RedisCollection.</returns>
+        public IRedisCollection<T> RedisCollection<T>(bool saveState, int chunkSize = 100)
+            where T : notnull => new RedisCollection<T>(Connection, saveState, chunkSize);
     }
 }

--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -97,7 +97,7 @@ namespace Redis.OM
                    null,
                    GetMethodInfo(Where, source, expression),
                    new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, combined, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, combined, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Redis.OM
                    null,
                    GetMethodInfo(Select, source, expression),
                    new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<TR>((RedisQueryProvider)source.Provider, exp, source.StateManager, null, source.ChunkSize);
+            return new RedisCollection<TR>((RedisQueryProvider)source.Provider, exp, source.StateManager, null, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(Skip, source, count),
                 new[] { source.Expression, Expression.Constant(count) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(Take, source, count),
                 new[] { source.Expression, Expression.Constant(count) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace Redis.OM
                 Expression.Constant(lat),
                 Expression.Constant(radius),
                 Expression.Constant(unit));
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -499,7 +499,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(OrderBy, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>
@@ -518,7 +518,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(OrderByDescending, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
         }
 
         /// <summary>

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -14,6 +14,11 @@ namespace Redis.OM.Searching
     public interface IRedisCollection<T> : IOrderedQueryable<T>, IAsyncEnumerable<T>
     {
         /// <summary>
+        /// Gets a value indicating whether gets whether the collection is meant to save the state of the records enumerated into it.
+        /// </summary>
+        bool SaveState { get; }
+
+        /// <summary>
         /// Gets the collection state manager.
         /// </summary>
         RedisCollectionStateManager StateManager { get; }

--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -96,7 +96,7 @@ namespace Redis.OM.Searching
             where TElement : notnull
         {
             var booleanExpression = expression as Expression<Func<TElement, bool>>;
-            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression);
+            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, true);
         }
 
         /// <inheritdoc/>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -794,5 +794,28 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 Assert.Equal("Changed",p.Name);
             } 
         }
+
+        [Fact]
+        public async Task TestShouldFailForSave()
+        {
+            var expectedText = "The RedisCollection has been instructed to not maintain the state of records enumerated by " +
+                               "Redis making the attempt to Save Invalid. Please initialize the RedisCollection with saveState " +
+                               "set to true to Save documents in the RedisCollection";
+            var collection = new RedisCollection<Person>(_connection, false, 100);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(collection.SaveAsync().AsTask);
+            Assert.Equal(expectedText, ex.Message);
+            ex = Assert.Throws<InvalidOperationException>(() =>collection.Save());
+            Assert.Equal(expectedText, ex.Message);
+        }
+
+        [Fact]
+        public async Task TestStatelessCollection()
+        {
+            var collection = new RedisCollection<Person>(_connection, false, 10000);
+            var res = await collection.ToListAsync();
+            Assert.True(res.Count >= 1);
+            Assert.Equal(0,collection.StateManager.Data.Count);
+            Assert.Equal(0,collection.StateManager.Snapshot.Count);
+        }
     }
 }


### PR DESCRIPTION
#189 points out an important point, many folks will not want the StateManager to maintain any of their records, whether this is because of the concurrency issues that are pointed out in there, or they just don't want very large collections of data initalized under the hood, giving folks the ability to configure this will be pretty helpful. Adding new path to allow users to decide whether or not to have said data stored.