### PR TITLE
fixing backwards contains queries.

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -598,6 +598,13 @@ namespace Redis.OM.Common
             {
                 var propertyExpression = (MemberExpression)exp.Arguments.Last();
                 var valuesExpression = (MemberExpression)exp.Arguments.First();
+                literal = GetOperandStringForQueryArgs(propertyExpression);
+                if (!literal.StartsWith("@"))
+                {
+                    propertyExpression = (MemberExpression)exp.Arguments.First();
+                    valuesExpression = (MemberExpression)exp.Arguments.Last();
+                }
+
                 var attribute = DetermineSearchAttribute(propertyExpression);
                 if (attribute == null)
                 {

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.2.2</PackageVersion>
-    <Version>0.2.2</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.2.2</PackageReleaseNotes>
+    <PackageVersion>0.2.3</PackageVersion>
+    <Version>0.2.3</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.2.3</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2150,7 +2150,26 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100"));
         }
-        
+
+        [Fact]
+        public void Issue201()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var p1 = new Person() {Name = "Steve"};
+            var collection = new RedisCollection<Person>(_mock.Object, 1000);
+            collection.Where(x=>x.NickNames.Contains(p1.Name)).ToList();
+            
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{Steve})",
+                "LIMIT",
+                "0",
+                "1000"
+            ));
+        }
         
 
     }


### PR DESCRIPTION
Fixes #201 - issue propagated when adding the inverted contains queries, when a search attribute is found on a property you are trying to search on. Adding a check to see if a literal value can be derived from the property being searched on prior to generating the query.