### PR TITLE
moving from redismod->redisstack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We welcome code contributions from the community, if you want to contribute code
 1. Fork this repo.
 2. Make your Code Changes.
 3. Write your tests.
-4. Use the `docker run -p 6379:6379 redislabs/redismod` as your local environment for running the functional tests.
+4. Use the `docker run -p 6379:6379 redis/redis-stack-server` as your local environment for running the functional tests.
 5. Verify the tests pass (there may be a couple of deployment-specific tests (e.g. Sentinel/Cluster) in Redis.OM which will fail outside of the GH environment we've setup so don't worry about those).
 6. If it's your first time contributing please add your Github handle the the Contributors section in the README.
 7. Push your changes to GitHub.

--- a/docker/cluster/dockerfile
+++ b/docker/cluster/dockerfile
@@ -1,4 +1,4 @@
-﻿FROM redislabs/redismod:preview
+﻿FROM redis/redis-stack-server
 
 RUN mkdir -p /redis
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ networks:
 
 services:  
   redis-standalone:
-    image: "redislabs/redismod:preview"
+    image: "redis/redis-stack-server"
     container_name: redis-standalone
     ports:
       - "6379"
@@ -27,7 +27,7 @@ services:
       cluster-network:
         ipv4_address: 192.168.57.18
   redis-replica:
-    image: "redislabs/redismod:preview"
+    image: "redis/redis-stack-server"
     container_name: redis-replica
     command: --port 6379 --loadmodule /usr/lib/redis/modules/redisai.so --loadmodule /usr/lib/redis/modules/redisearch.so --loadmodule /usr/lib/redis/modules/redisgraph.so --loadmodule /usr/lib/redis/modules/redistimeseries.so --loadmodule /usr/lib/redis/modules/rejson.so --loadmodule /usr/lib/redis/modules/redisbloom.so --loadmodule /var/opt/redislabs/lib/modules/redisgears.so Plugin /var/opt/redislabs/modules/rg/plugin/gears_python.so --slaveof redis-master 6379
     ports:

--- a/docker/sentinel/dockerfile
+++ b/docker/sentinel/dockerfile
@@ -1,4 +1,4 @@
-FROM redislabs/redismod:preview
+FROM redis/redis-stack-server
 
 ENV SENTINEL_QUORUM 2
 ENV SENTINEL_DOWN_AFTER 1000

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -30,7 +30,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var names = new[] { "Steve", "Sarah", "Chris", "Theresa", "Frank", "Mary", "John", "Alice", "Bob" };
             var rand = new Random();
             var tasks = new List<Task>();
-            for (var i = 0; i < 500; i++)
+            for (var i = 0; i < 50; i++)
             {
                 var person = new HashPerson()
                 {
@@ -54,7 +54,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var names = new[] { "Steve", "Sarah", "Chris", "Theresa", "Frank", "Mary", "John", "Alice", "Bob" };
             var rand = new Random();
             var tasks = new List<Task>();
-            for (var i = 0; i < 500; i++)
+            for (var i = 0; i < 50; i++)
             {
                 var person = new Person
                 {


### PR DESCRIPTION
Moving to redis-stack image from redis mod (needed to make a slight change to unit tests because of default configuration of redis-stack)