### PR TITLE
moving stuff for internal scripts to internal

### DIFF
--- a/src/Redis.OM.POC/RedisCommands.cs
+++ b/src/Redis.OM.POC/RedisCommands.cs
@@ -443,7 +443,7 @@ namespace Redis.OM
         }
         #endregion
         #region scripting
-        public static int? Eval(this IRedisConnection connection, string script, string[] keys, string[] argv)
+        internal static int? Eval(this IRedisConnection connection, string script, string[] keys, string[] argv)
         {
             var args = new List<string>();
             args.Add(script);
@@ -453,7 +453,7 @@ namespace Redis.OM
             return connection.Execute("EVAL", args.ToArray());
         }
         
-        public static async Task<int?> EvalAsync(this IRedisConnection connection, string script, string[] keys, string[] argv)
+        internal static async Task<int?> EvalAsync(this IRedisConnection connection, string script, string[] keys, string[] argv)
         {
             var args = new List<string>();
             args.Add(script);
@@ -463,7 +463,7 @@ namespace Redis.OM
             return await connection.ExecuteAsync("EVAL", args.ToArray());
         }
 
-        public static async Task<int?> CreateAndEvalAsync(this IRedisConnection connection, string scriptName, string[] keys,
+        internal static async Task<int?> CreateAndEvalAsync(this IRedisConnection connection, string scriptName, string[] keys,
             string[] argv, string fullScript = "")
         {
             string sha;
@@ -494,7 +494,7 @@ namespace Redis.OM
 
         }
         
-        public static int? CreateAndEval(this IRedisConnection connection, string scriptName, string[] keys,
+        internal static int? CreateAndEval(this IRedisConnection connection, string scriptName, string[] keys,
             string[] argv, string fullScript = "")
         {
             string sha;


### PR DESCRIPTION
This will resolve #214, the APIs being moved to internal here were never intended for public consumption, they were meant to load and execute the highly specialized update scripts that I wrote for executing minimal updates against redis. This will constitute a minor breaking change to Redis OM, and will therefore require the version bearing it to rev to v0.3.0.