### PR TITLE
Bugfix for GeoLoc Serialization in Different Cultures

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@AmirEsdeki](https://github.com/AmirEsdeki)
 * [@Zulander1](https://github.com/zulander1)
 * [@Jeevananthan](https://github.com/Jeevananthan-23)
+* [@mariusmuntean](https://github.com/mariusmuntean)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/GeoLoc.cs
+++ b/src/Redis.OM/GeoLoc.cs
@@ -53,7 +53,7 @@ namespace Redis.OM.Modeling
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Longitude},{Latitude}";
+            return $"{Longitude.ToString(CultureInfo.InvariantCulture)},{Latitude.ToString(CultureInfo.InvariantCulture)}";
         }
     }
 }

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.3.0</PackageVersion>
-    <Version>0.3.0</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.3.0</PackageReleaseNotes>
+    <PackageVersion>0.3.1</PackageVersion>
+    <Version>0.3.1</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.3.1</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/test/Redis.OM.Unit.Tests/GeoLocTests.cs
+++ b/test/Redis.OM.Unit.Tests/GeoLocTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using Redis.OM.Modeling;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -38,6 +39,19 @@ namespace Redis.OM.Unit.Tests
         public void TestInvariantCultureParsingFromFormattedHash()
         {
             Helper.RunTestUnderDifferentCulture("it-IT", x => TestParsingFromFormattedHash());
+        }
+
+        [Theory]
+        [InlineData("en-DE")]
+        [InlineData("it-IT")]
+        public void TestToStringInOtherCultures(string lcid)
+        {
+            Helper.RunTestUnderDifferentCulture(lcid, o =>
+            {
+                var geoLoc = new GeoLoc(45.2, 11.9);
+                var geoLocStr = geoLoc.ToString();
+                Assert.Equal("45.2,11.9", geoLocStr);
+            });
         }
     }
 }


### PR DESCRIPTION
GeoLoc.ToString() doesn't produce a stable output if the culture changes.
This PR fixes that - see #229 