### PR TITLE
adding ability to index and query datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Once the index is created, we can:
 
 Let's see how!
 
+### Indexing DateTimes
+
+As of version 0.4.0, all DateTime objects are indexed as numerics, and they are inserted as numerics into JSON documents. Because of this, you can query them as if they were numerics!
+
 ### 🔑 Keys and Ids
 
 #### ULIDs and strings

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -673,6 +673,11 @@ namespace Redis.OM.Common
                 return ((double)value).ToString(CultureInfo.InvariantCulture);
             }
 
+            if (value is DateTime dt)
+            {
+                return new DateTimeOffset(dt).ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+            }
+
             return value.ToString();
         }
 

--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -332,7 +332,7 @@ namespace Redis.OM.Common
                     }
                     else
                     {
-                        if (!int.TryParse(rightContent, out _))
+                        if (!int.TryParse(rightContent, out _) && !long.TryParse(rightContent, out _))
                         {
                             rightContent = ((int)Enum.Parse(member.Type, rightContent)).ToString();
                         }

--- a/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
+++ b/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
@@ -12,15 +12,16 @@ namespace Redis.OM.Modeling
         /// <inheritdoc />
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var val = reader.GetString();
+            long val = reader.TokenType == JsonTokenType.String ? long.Parse(reader.GetString() !) : reader.GetInt64();
+
             DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return TimeZoneInfo.ConvertTimeFromUtc(dateTime.AddMilliseconds(long.Parse(val!)), TimeZoneInfo.Local);
+            return TimeZoneInfo.ConvertTimeFromUtc(dateTime.AddMilliseconds(val), TimeZoneInfo.Local);
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(new DateTimeOffset(value).ToUnixTimeMilliseconds().ToString());
+            writer.WriteNumberValue(new DateTimeOffset(value).ToUnixTimeMilliseconds());
         }
     }
 }

--- a/src/Redis.OM/Modeling/TypeDeterminationUtilities.cs
+++ b/src/Redis.OM/Modeling/TypeDeterminationUtilities.cs
@@ -24,6 +24,7 @@ namespace Redis.OM.Modeling
             typeof(uint),
             typeof(ushort),
             typeof(float),
+            typeof(DateTime),
         };
 
         /// <summary>

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.3.1</PackageVersion>
-    <Version>0.3.1</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.3.1</PackageReleaseNotes>
+    <PackageVersion>0.4.0</PackageVersion>
+    <Version>0.4.0</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.4.0</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithDateTime.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithDateTime.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests;
+
+[Document(StorageType = StorageType.Json)]
+public class ObjectWithDateTime
+{
+    [RedisField]
+    public string Id { get; set; }
+    [Indexed(Sortable = true)]
+    public DateTime Timestamp { get; set; }
+    [Indexed]
+    public DateTime? NullableTimestamp { get; set; }
+}
+
+[Document(StorageType = StorageType.Hash)]
+public class ObjectWithDateTimeHash
+{
+    [RedisField]
+    public string Id { get; set; }
+    
+    [Indexed]
+    public DateTime Timestamp { get; set; }
+    [Indexed]
+    public DateTime? NullableTimestamp { get; set; }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -1684,7 +1684,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "1",
                 "Redis.OM.Unit.Tests.RediSearchTests.ObjectWithDateTime:",
                 "SCHEMA",
-                "$.Timestamp", "AS", "Timestamp", "NUMERIC",
+                "$.Timestamp", "AS", "Timestamp", "NUMERIC", "SORTABLE",
                 "$.NullableTimestamp", "AS", "NullableTimestamp", "NUMERIC"
             ));
             

--- a/test/Redis.OM.Unit.Tests/RedisSetupCollection.cs
+++ b/test/Redis.OM.Unit.Tests/RedisSetupCollection.cs
@@ -22,6 +22,8 @@ namespace Redis.OM.Unit.Tests
             Connection.CreateIndex(typeof(ObjectWithEmbeddedArrayOfObjects));
             Connection.CreateIndex(typeof(ObjectWithZeroStopwords));
             Connection.CreateIndex(typeof(ObjectWithTwoStopwords));
+            Connection.CreateIndex(typeof(ObjectWithDateTime));
+            Connection.CreateIndex(typeof(ObjectWithDateTimeHash));
         }
 
         private IRedisConnection _connection = null;
@@ -53,6 +55,9 @@ namespace Redis.OM.Unit.Tests
             Connection.DropIndexAndAssociatedRecords(typeof(ObjectWithZeroStopwords));
             Connection.DropIndexAndAssociatedRecords(typeof(ObjectWithTwoStopwords));
             Connection.DropIndexAndAssociatedRecords(typeof(ClassForEmptyRedisCollection));
+            Connection.DropIndexAndAssociatedRecords(typeof(ObjectWithDateTime));
+            Connection.DropIndexAndAssociatedRecords(typeof(ObjectWithDateTimeHash));
+            
         }
     }
 }


### PR DESCRIPTION
Adds ability to index and query DateTimes in Redis with Redis OM, this will be a SOMEWHAT breaking change, because the mode of storage of DateTimes in Redis is changing from strings to numerics, this shouldn't effect anyone only working in Redis OM and interacting with said datetimes because the JSON parser is setup to handle both cases, but all the same it's changing the behavior at storage, so I'm revving to 0.4.0