### PR TITLE
Adding comma separators to flag enums

### DIFF
--- a/src/Redis.OM/Modeling/RedisSchemaField.cs
+++ b/src/Redis.OM/Modeling/RedisSchemaField.cs
@@ -158,6 +158,8 @@ namespace Redis.OM.Modeling
             return TypeDeterminationUtilities.IsNumeric(declaredType) ? "NUMERIC" : "TAG";
         }
 
+        private static bool IsEnumTypeFlags(Type type) => type.GetCustomAttributes(typeof(FlagsAttribute), false).Any();
+
         private static string[] CommonSerialization(SearchFieldAttribute attr, Type declaredType, PropertyInfo propertyInfo)
         {
             var searchFieldType = GetSearchFieldType(declaredType, attr, propertyInfo);
@@ -188,6 +190,11 @@ namespace Redis.OM.Modeling
                 {
                     ret.Add("SEPARATOR");
                     ret.Add(tag.Separator.ToString());
+                }
+                else if (declaredType.IsEnum && IsEnumTypeFlags(declaredType))
+                {
+                    ret.Add("SEPARATOR");
+                    ret.Add(",");
                 }
 
                 if (tag.CaseSensitive)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/EnumFlags.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/EnumFlags.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests;
+
+[Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EnumFlags
+{
+    None = 0,
+    One = 1 << 0,
+    Two = 1 << 1,
+    Three = 1 << 2
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithStringLikeValueTypes.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithStringLikeValueTypes.cs
@@ -22,6 +22,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         
         [Indexed]
         public AnEnum AnEnumAsInt { get; set; }
+
+        [Indexed]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public EnumFlags Flags { get; set; }
     }
     
     [Document]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -858,5 +858,15 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(0,collection.StateManager.Data.Count);
             Assert.Equal(0,collection.StateManager.Snapshot.Count);
         }
+
+        [Fact]
+        public async Task TestFlagEnumQuery()
+        {
+            var collection = new RedisCollection<ObjectWithStringLikeValueTypes>(_connection, false, 10000);
+            var obj = new ObjectWithStringLikeValueTypes { Flags = EnumFlags.One | EnumFlags.Two };
+            await collection.InsertAsync(obj);
+            var res = await collection.FirstOrDefaultAsync(x => x.Flags == EnumFlags.One);
+            Assert.NotNull(res);
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -1630,17 +1630,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "1",
                 "Redis.OM.Unit.Tests.RediSearchTests.ObjectWithStringLikeValueTypes:",
                 "SCHEMA",
-                "$.Ulid",
-                "AS",
-                "Ulid",
-                "TAG", "SEPARATOR", "|",
-                "$.Boolean",
-                "AS",
-                "Boolean",
-                "TAG", "SEPARATOR", "|",
-                "$.Guid",
-                "AS", "Guid", "TAG", "SEPARATOR", "|", "$.AnEnum", "AS", "AnEnum", "TAG",
-                "$.AnEnumAsInt", "AS", "AnEnumAsInt","NUMERIC"
+                "$.Ulid", "AS", "Ulid", "TAG", "SEPARATOR", "|",
+                "$.Boolean", "AS", "Boolean", "TAG", "SEPARATOR", "|",
+                "$.Guid", "AS", "Guid", "TAG", "SEPARATOR", "|",
+                "$.AnEnum", "AS", "AnEnum", "TAG",
+                "$.AnEnumAsInt", "AS", "AnEnumAsInt","NUMERIC",
+                "$.Flags", "AS", "Flags", "TAG", "SEPARATOR", ","
                 ));
         }
 


### PR DESCRIPTION
Closes #239 - When the Enum feature was originally added I hadn't accounted for Flag enums - this allows you to properly set and query flag enums in Redis OM.