### PR TITLE
adding ability to add prefixes to indexes for Searches

### DIFF
--- a/src/Redis.OM/Aggregation/RedisAggregationSet.cs
+++ b/src/Redis.OM/Aggregation/RedisAggregationSet.cs
@@ -37,7 +37,7 @@ namespace Redis.OM.Aggregation
             }
 
             _chunkSize = chunkSize;
-            Initialize(new RedisQueryProvider(connection, rootAttribute, _chunkSize, true), null, useCursor);
+            Initialize(new RedisQueryProvider(connection, rootAttribute, _chunkSize, true, string.Empty), null, useCursor);
         }
 
         /// <summary>

--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -180,9 +180,10 @@ namespace Redis.OM.Common
         /// <param name="expression">The expression.</param>
         /// <param name="type">The root type.</param>
         /// <param name="mainBooleanExpression">The primary boolean expression to build the filter from.</param>
+        /// <param name="prefix">The index to use when creating the indexName.</param>
         /// <returns>A Redis query.</returns>
         /// <exception cref="InvalidOperationException">Thrown if type is missing indexing.</exception>
-        internal static RedisQuery BuildQueryFromExpression(Expression expression, Type type, Expression? mainBooleanExpression)
+        internal static RedisQuery BuildQueryFromExpression(Expression expression, Type type, Expression? mainBooleanExpression, string prefix)
         {
             var attr = type.GetCustomAttribute<DocumentAttribute>();
             if (attr == null)
@@ -190,7 +191,8 @@ namespace Redis.OM.Common
                 throw new InvalidOperationException("Searches can only be performed on objects decorated with a RedisObjectDefinitionAttribute that specifies a particular index");
             }
 
-            var indexName = string.IsNullOrEmpty(attr.IndexName) ? $"{type.Name.ToLower()}-idx" : attr.IndexName;
+            var prefixAddendum = string.IsNullOrEmpty(prefix) ? string.Empty : $"-{prefix}";
+            var indexName = string.IsNullOrEmpty(attr.IndexName) ? $"{type.Name.ToLower()}{prefixAddendum}-idx" : $"{attr.IndexName}{prefixAddendum}";
             var query = new RedisQuery(indexName!) { QueryText = "*" };
             switch (expression)
             {

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -71,12 +71,64 @@ namespace Redis.OM
         /// </summary>
         /// <param name="connection">the connection.</param>
         /// <param name="type">the type to use for creating the index.</param>
+        /// <param name="prefix">The prefix for the index, this will override the prefix property in the type's DocumentAttribute.</param>
+        /// <returns>whether the index was created or not.</returns>
+        public static bool CreateIndex(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var serializedParams = type.SerializeIndex(prefix);
+                connection.Execute("FT.CREATE", serializedParams);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Index already exists"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an index.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to use for creating the index.</param>
         /// <returns>whether the index was created or not.</returns>
         public static async Task<bool> CreateIndexAsync(this IRedisConnection connection, Type type)
         {
             try
             {
                 var serializedParams = type.SerializeIndex();
+                await connection.ExecuteAsync("FT.CREATE", serializedParams);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Index already exists"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an index.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to use for creating the index.</param>
+        /// <param name="prefix">The prefix for the index, this will override the prefix property in the type's DocumentAttribute.</param>
+        /// <returns>whether the index was created or not.</returns>
+        public static async Task<bool> CreateIndexAsync(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var serializedParams = type.SerializeIndex(prefix);
                 await connection.ExecuteAsync("FT.CREATE", serializedParams);
                 return true;
             }
@@ -173,12 +225,64 @@ namespace Redis.OM
         /// </summary>
         /// <param name="connection">the connection.</param>
         /// <param name="type">the type to drop the index for.</param>
+        /// <param name="prefix">The prefix used to create the index.</param>
+        /// <returns>whether the index was dropped or not.</returns>
+        public static async Task<bool> DropIndexAsync(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var indexName = type.SerializeIndex(prefix).First();
+                await connection.ExecuteAsync("FT.DROPINDEX", indexName);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes an index.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to drop the index for.</param>
         /// <returns>whether the index was dropped or not.</returns>
         public static bool DropIndex(this IRedisConnection connection, Type type)
         {
             try
             {
                 var indexName = type.SerializeIndex().First();
+                connection.Execute("FT.DROPINDEX", indexName);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes an index.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to drop the index for.</param>
+        /// <param name="prefix">The prefix used to create the index.</param>
+        /// <returns>whether the index was dropped or not.</returns>
+        public static bool DropIndex(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var indexName = type.SerializeIndex(prefix).First();
                 connection.Execute("FT.DROPINDEX", indexName);
                 return true;
             }
@@ -205,6 +309,58 @@ namespace Redis.OM
             {
                 var indexName = type.SerializeIndex().First();
                 connection.Execute("FT.DROPINDEX", indexName, "DD");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes an index. And drops associated records.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to drop the index for.</param>
+        /// <param name="prefix">The prefix associated with the index.</param>
+        /// <returns>whether the index was dropped or not.</returns>
+        public static bool DropIndexAndAssociatedRecords(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var indexName = type.SerializeIndex(prefix).First();
+                connection.Execute("FT.DROPINDEX", indexName, "DD");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Unknown Index name"))
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes an index. And drops associated records.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="type">the type to drop the index for.</param>
+        /// <param name="prefix">The prefix associated with the index.</param>
+        /// <returns>whether the index was dropped or not.</returns>
+        public static async Task<bool> DropIndexAndAssociatedRecordsAsync(this IRedisConnection connection, Type type, string prefix)
+        {
+            try
+            {
+                var indexName = type.SerializeIndex(prefix).First();
+                await connection.ExecuteAsync("FT.DROPINDEX", indexName, "DD");
                 return true;
             }
             catch (Exception ex)

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -33,9 +33,18 @@ namespace Redis.OM
         /// <param name="connection">connection to redis.</param>
         /// <param name="obj">the object to save.</param>
         /// <returns>the key for the object.</returns>
-        public static async Task<string> SetAsync(this IRedisConnection connection, object obj)
+        public static Task<string> SetAsync(this IRedisConnection connection, object obj) => connection.SetAsync(obj, null);
+
+        /// <summary>
+        /// Serializes an object to either hash or json (depending on how it's decorated), and saves it in redis.
+        /// </summary>
+        /// <param name="connection">connection to redis.</param>
+        /// <param name="obj">the object to save.</param>
+        /// <param name="prefix">The prefix to use when generating the keyname for the object inserted.</param>
+        /// <returns>the key for the object.</returns>
+        public static async Task<string> SetAsync(this IRedisConnection connection, object obj, string? prefix)
         {
-            var id = obj.SetId();
+            var id = obj.SetId(prefix);
             var type = obj.GetType();
             var attr = Attribute.GetCustomAttribute(type, typeof(DocumentAttribute)) as DocumentAttribute;
             if (attr == null || attr.StorageType == StorageType.Hash)
@@ -64,9 +73,19 @@ namespace Redis.OM
         /// <param name="obj">the object to save.</param>
         /// <param name="timeSpan">the expiry date of the key (TTL).</param>
         /// <returns>the key for the object.</returns>
-        public static async Task<string> SetAsync(this IRedisConnection connection, object obj, TimeSpan timeSpan)
+        public static Task<string> SetAsync(this IRedisConnection connection, object obj, TimeSpan timeSpan) => connection.SetAsync(obj, timeSpan, null);
+
+        /// <summary>
+        /// Serializes an object to either hash or json (depending on how it's decorated), and saves it in redis.
+        /// </summary>
+        /// <param name="connection">connection to redis.</param>
+        /// <param name="obj">the object to save.</param>
+        /// <param name="timeSpan">the expiry date of the key (TTL).</param>
+        /// /// <param name="prefix">The prefix to use when generating the keyname for the object inserted.</param>
+        /// <returns>the key for the object.</returns>
+        public static async Task<string> SetAsync(this IRedisConnection connection, object obj, TimeSpan timeSpan, string? prefix)
         {
-            var id = obj.SetId();
+            var id = obj.SetId(prefix);
             var type = obj.GetType();
             var attr = Attribute.GetCustomAttribute(type, typeof(DocumentAttribute)) as DocumentAttribute;
             if (attr == null || attr.StorageType == StorageType.Hash)
@@ -292,9 +311,18 @@ namespace Redis.OM
         /// <param name="connection">connection to redis.</param>
         /// <param name="obj">the object to save.</param>
         /// <returns>the key for the object.</returns>
-        public static string Set(this IRedisConnection connection, object obj)
+        public static string Set(this IRedisConnection connection, object obj) => connection.Set(obj, null);
+
+        /// <summary>
+        /// Serializes an object to either hash or json (depending on how it's decorated), and saves it in redis.
+        /// </summary>
+        /// <param name="connection">connection to redis.</param>
+        /// <param name="obj">the object to save.</param>
+        /// <param name="prefix">The overriding prefix to use for the keyname.</param>
+        /// <returns>the key for the object.</returns>
+        public static string Set(this IRedisConnection connection, object obj, string? prefix)
         {
-            var id = obj.SetId();
+            var id = obj.SetId(prefix);
             var type = obj.GetType();
             if (Attribute.GetCustomAttribute(type, typeof(DocumentAttribute)) is not DocumentAttribute attr || attr.StorageType == StorageType.Hash)
             {
@@ -322,9 +350,19 @@ namespace Redis.OM
         /// <param name="obj">the object to save.</param>
         /// <param name="timeSpan">the the timespan to set for your (TTL).</param>
         /// <returns>the key for the object.</returns>
-        public static string Set(this IRedisConnection connection, object obj, TimeSpan timeSpan)
+        public static string Set(this IRedisConnection connection, object obj, TimeSpan timeSpan) => connection.Set(obj, timeSpan, null);
+
+        /// <summary>
+        /// Serializes an object to either hash or json (depending on how it's decorated), and saves it in redis.
+        /// </summary>
+        /// <param name="connection">connection to redis.</param>
+        /// <param name="obj">the object to save.</param>
+        /// <param name="timeSpan">the the timespan to set for your (TTL).</param>
+        /// <param name="prefix">The overriden prefix to use for the keyname.</param>
+        /// <returns>the key for the object.</returns>
+        public static string Set(this IRedisConnection connection, object obj, TimeSpan timeSpan, string? prefix)
         {
-            var id = obj.SetId();
+            var id = obj.SetId(prefix);
             var type = obj.GetType();
             if (Attribute.GetCustomAttribute(type, typeof(DocumentAttribute)) is not DocumentAttribute attr || attr.StorageType == StorageType.Hash)
             {

--- a/src/Redis.OM/RedisConnectionProvider.cs
+++ b/src/Redis.OM/RedisConnectionProvider.cs
@@ -79,6 +79,17 @@ namespace Redis.OM
         /// <param name="chunkSize">Size of chunks to use during pagination, larger chunks = larger payloads returned but fewer round trips.</param>
         /// <returns>A RedisCollection.</returns>
         public IRedisCollection<T> RedisCollection<T>(bool saveState, int chunkSize = 100)
-            where T : notnull => new RedisCollection<T>(Connection, saveState, chunkSize);
+            where T : notnull => new RedisCollection<T>(Connection, saveState, chunkSize, string.Empty);
+
+        /// <summary>
+        /// Gets a redis collection.
+        /// </summary>
+        /// <typeparam name="T">The type the collection will be retrieving.</typeparam>
+        /// <param name="saveState">Whether or not the RedisCollection should maintain the state of documents it enumerates.</param>
+        /// <param name="chunkSize">Size of chunks to use during pagination, larger chunks = larger payloads returned but fewer round trips.</param>
+        /// <param name="prefix">The Prefix to use when creating index, as well as for inserting keys and querying them.</param>
+        /// <returns>A RedisCollection.</returns>
+        public IRedisCollection<T> RedisCollection<T>(bool saveState, int chunkSize, string prefix)
+            where T : notnull => new RedisCollection<T>(Connection, saveState, chunkSize, prefix);
     }
 }

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -135,9 +135,10 @@ namespace Redis.OM
         /// Gets the fully formed key name for the given object.
         /// </summary>
         /// <param name="obj">the object to pull the key from.</param>
+        /// <param name="prefix">The Prefix to which overloads the DocumentAttribute's prefix.</param>
         /// <returns>The key.</returns>
         /// <exception cref="ArgumentException">Thrown if type is invalid or there's no id present on the key.</exception>
-        internal static string GetKey(this object obj)
+        internal static string GetKey(this object obj, string? prefix)
         {
             var type = obj.GetType();
             var documentAttribute = (DocumentAttribute)type.GetCustomAttribute(typeof(DocumentAttribute));
@@ -153,7 +154,7 @@ namespace Redis.OM
             }
 
             var sb = new StringBuilder();
-            sb.Append(GetKeyPrefix(type));
+            sb.Append(string.IsNullOrEmpty(prefix) ? GetKeyPrefix(type) : prefix);
             sb.Append(":");
             sb.Append(id);
 
@@ -185,10 +186,11 @@ namespace Redis.OM
         /// Set's the id of the given field based off the objects id strategy.
         /// </summary>
         /// <param name="obj">The object to set the field of.</param>
+        /// <param name="prefix">The prefix to use for they key, this will overload the prefixes within the type definition.</param>
         /// <returns>The id.</returns>
         /// <exception cref="InvalidOperationException">Thrown if Id property is of invalid type.</exception>
         /// <exception cref="MissingMemberException">Thrown if class is missing a document attribute decoration.</exception>
-        internal static string SetId(this object obj)
+        internal static string SetId(this object obj, string? prefix)
         {
             var type = obj.GetType();
             var attr = Attribute.GetCustomAttribute(type, typeof(DocumentAttribute)) as DocumentAttribute;
@@ -234,6 +236,11 @@ namespace Redis.OM
                         idProperty.SetValue(obj, id);
                     }
                 }
+            }
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                return $"{prefix}:{id}";
             }
 
             if (attr.Prefixes == null || string.IsNullOrEmpty(attr.Prefixes.FirstOrDefault()))

--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -97,7 +97,7 @@ namespace Redis.OM
                    null,
                    GetMethodInfo(Where, source, expression),
                    new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, combined, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, combined, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Redis.OM
                    null,
                    GetMethodInfo(Select, source, expression),
                    new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<TR>((RedisQueryProvider)source.Provider, exp, source.StateManager, null, source.SaveState, source.ChunkSize);
+            return new RedisCollection<TR>((RedisQueryProvider)source.Provider, exp, source.StateManager, null, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(Skip, source, count),
                 new[] { source.Expression, Expression.Constant(count) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(Take, source, count),
                 new[] { source.Expression, Expression.Constant(count) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace Redis.OM
                 Expression.Constant(lat),
                 Expression.Constant(radius),
                 Expression.Constant(unit));
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -499,7 +499,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(OrderBy, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>
@@ -518,7 +518,7 @@ namespace Redis.OM
                 null,
                 GetMethodInfo(OrderByDescending, source, expression),
                 new[] { source.Expression, Expression.Quote(expression) });
-            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.Prefix, source.ChunkSize);
         }
 
         /// <summary>

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -29,6 +29,47 @@ namespace Redis.OM.Searching
         int ChunkSize { get; }
 
         /// <summary>
+        /// Gets the prefix that the collection uses when generating indexes, keys, and querying.
+        /// </summary>
+        string Prefix { get; }
+
+        /// <summary>
+        /// Creates an index from the collection's type and prefix.
+        /// </summary>
+        /// <returns>Whether or not the index was created.</returns>
+        bool CreateIndex();
+
+        /// <summary>
+        /// Drops the index associated with the collection.
+        /// </summary>
+        /// <returns>Whether or not the index was dropped.</returns>
+        bool DropIndex();
+
+        /// <summary>
+        /// Drops the index associated with the collection AS WELL AS ALL THE RECORDS IT INDEXES.
+        /// </summary>
+        /// <returns>Whether or not the index was dropped.</returns>
+        bool DropIndexWithAssociatedRecords();
+
+        /// <summary>
+        /// Creates an index from the collection's type and prefix.
+        /// </summary>
+        /// <returns>Whether or not the index was created.</returns>
+        Task<bool> CreateIndexAsync();
+
+        /// <summary>
+        /// Drops the index associated with the collection.
+        /// </summary>
+        /// <returns>Whether or not the index was dropped.</returns>
+        Task<bool> DropIndexAsync();
+
+        /// <summary>
+        /// Drops the index associated with the collection AS WELL AS ALL THE RECORDS IT INDEXES.
+        /// </summary>
+        /// <returns>Whether or not the index was dropped.</returns>
+        Task<bool> DropIndexWithAssociatedRecordsAsync();
+
+        /// <summary>
         /// Saves the current state of the collection, overriding what was initially materialized.
         /// </summary>
         void Save();

--- a/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
+++ b/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
@@ -25,6 +25,7 @@ namespace Redis.OM.Searching
         private readonly bool _saveState;
         private readonly IRedisConnection _connection;
         private readonly RedisCollectionStateManager _stateManager;
+        private readonly string _prefix;
         private SearchResponse<T> _records = new (new RedisReply(new RedisReply[] { 0 }));
         private bool _started;
         private int _index = -1;
@@ -38,7 +39,8 @@ namespace Redis.OM.Searching
         /// <param name="stateManager">the state manager.</param>
         /// <param name="booleanExpression">The main boolean expression to use to build the filter.</param>
         /// <param name="saveState">Determins whether the records from the RedisCollection are stored in the StateManager.</param>
-        public RedisCollectionEnumerator(Expression exp, IRedisConnection connection, int chunkSize, RedisCollectionStateManager stateManager, Expression<Func<T, bool>>? booleanExpression, bool saveState)
+        /// <param name="prefix">The prefix to use for crafting the index name.</param>
+        public RedisCollectionEnumerator(Expression exp, IRedisConnection connection, int chunkSize, RedisCollectionStateManager stateManager, Expression<Func<T, bool>>? booleanExpression, bool saveState, string prefix)
         {
             Type rootType;
             var t = typeof(T);
@@ -53,7 +55,7 @@ namespace Redis.OM.Searching
                 rootType = t;
             }
 
-            _query = ExpressionTranslator.BuildQueryFromExpression(exp, rootType, booleanExpression);
+            _query = ExpressionTranslator.BuildQueryFromExpression(exp, rootType, booleanExpression, prefix);
             if (_query.Limit != null)
             {
                 _limited = true;
@@ -66,6 +68,7 @@ namespace Redis.OM.Searching
             _connection = connection;
             _stateManager = stateManager;
             _saveState = saveState;
+            _prefix = prefix;
         }
 
         /// <summary>

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -103,11 +103,11 @@ namespace Redis.OM.Unit.Tests
 
             Thread.Sleep(1500);
 
-            var hashNotExpired = connection.HGetAll(hashObj.GetKey());
-            var hashExpired = connection.HGetAll(hashObjWithExpire.GetKey());
+            var hashNotExpired = connection.HGetAll(hashObj.GetKey(null));
+            var hashExpired = connection.HGetAll(hashObjWithExpire.GetKey(null));
 
-            var jsonNotExpired = connection.JsonGet(jsonObj.GetKey());
-            var jsonExpired = connection.JsonGet(jsonObjWithExpire.GetKey());
+            var jsonNotExpired = connection.JsonGet(jsonObj.GetKey(null));
+            var jsonExpired = connection.JsonGet(jsonObjWithExpire.GetKey(null));
 
             Assert.Equal( 2, hashNotExpired.Count);
             Assert.Equal(0, hashExpired.Count);
@@ -137,11 +137,11 @@ namespace Redis.OM.Unit.Tests
 
             Thread.Sleep(1500);
 
-            var hashNotExpired = await connection.HGetAllAsync(hashObj.GetKey());
-            var hashExpired = await connection.HGetAllAsync(hashObjWithExpire.GetKey());
+            var hashNotExpired = await connection.HGetAllAsync(hashObj.GetKey(null));
+            var hashExpired = await connection.HGetAllAsync(hashObjWithExpire.GetKey(null));
 
-            var jsonNotExpired = await connection.JsonGetAsync(jsonObj.GetKey());
-            var jsonExpired = await connection.JsonGetAsync(jsonObjWithExpire.GetKey());
+            var jsonNotExpired = await connection.JsonGetAsync(jsonObj.GetKey(null));
+            var jsonExpired = await connection.JsonGetAsync(jsonObjWithExpire.GetKey(null));
 
             Assert.Equal(2, hashNotExpired.Count);
             Assert.Equal(0, hashExpired.Count);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SimpleObject.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SimpleObject.cs
@@ -1,0 +1,18 @@
+﻿using Redis.OM.Modeling;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests;
+
+[Document(StorageType = StorageType.Json)]
+public class SimpleObject
+{
+    [RedisIdField] public string Id { get; set; }
+    [Indexed]
+    public string Name { get; set; }
+}
+
+[Document(StorageType = StorageType.Hash)]
+public class SimpleObjectHash
+{
+    [Indexed]
+    public string Name { get; set; }
+}


### PR DESCRIPTION
Adds overload to to RedisCollection to enable you to create your own prefixes dynamically, this is helpful for cases such as #242 where someone might want to have an index per tenant with it's own set of prefixes.

Basically now you initalize a RedisCollection<T> with a prefix, that prefix then becomes what your Collection uses to:

1. Serialize the index - the index name is generated as {classnametolower}-{prefix}-idx, and of course the prefixe for the index is the specified prefix.
2. At insertion into redis, the objects are given a keyname that is: `{prefix}:{id}`
3. When Querying, the collection uses the new sub-tenants index in the query.
