### PR TITLE
fix:backward-contains-list-type-queries

### DIFF
--- a/examples/Redis.OM.FullTextSearch/Program.cs
+++ b/examples/Redis.OM.FullTextSearch/Program.cs
@@ -19,7 +19,7 @@ connection.CreateIndex(typeof(Movie));
 connection.CreateIndex(typeof(Awards));
 
 var redisHelper = new RedisHelper(provider);
-redisHelper.InitializeCustomers();
+redisHelper.InitializeMovies();
 
 //BasicFirstOrDefaultQuery
 // get first or default null value from movies redis limit set to 0 to 1

--- a/examples/Redis.OM.FullTextSearch/RedisHelper/RedisHelper.cs
+++ b/examples/Redis.OM.FullTextSearch/RedisHelper/RedisHelper.cs
@@ -13,7 +13,7 @@ namespace Redis.OM.FullTextSearch.RedisHelper
             movieCollection = provider.RedisCollection<Movie>();
         }
 
-        public void InitializeCustomers()
+        public void InitializeMovies()
         {
             var count = movieCollection.Count();
             if (count > 0)
@@ -22,7 +22,7 @@ namespace Redis.OM.FullTextSearch.RedisHelper
                 return;
             }
 
-            Console.WriteLine("Initialize Customer Data...");
+            Console.WriteLine("Initialize Movie Data...");
 
             movieCollection.Insert(new Movie()
             {

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -588,7 +588,7 @@ namespace Redis.OM.Common
             Type type;
             string memberName;
             string literal;
-            if (exp.Object is MemberExpression)
+            if (exp.Object is MemberExpression && exp.Object.ToString().Contains("x."))
             {
                 expression = exp.Object as MemberExpression;
             }
@@ -602,6 +602,11 @@ namespace Redis.OM.Common
                 {
                     propertyExpression = (MemberExpression)exp.Arguments.First();
                     valuesExpression = (MemberExpression)exp.Arguments.Last();
+                }
+                else if (propertyExpression == valuesExpression)
+                {
+                    propertyExpression = (MemberExpression)exp.Arguments.First();
+                    valuesExpression = (MemberExpression)exp.Object;
                 }
 
                 var attribute = DetermineSearchAttribute(propertyExpression);

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -588,12 +588,7 @@ namespace Redis.OM.Common
             Type type;
             string memberName;
             string literal;
-            if (exp.Object is MemberExpression && exp.Object.ToString().StartsWith("x."))
-            {
-                expression = exp.Object as MemberExpression;
-            }
-            else if (exp.Arguments.LastOrDefault() is MemberExpression &&
-                     exp.Arguments.FirstOrDefault() is MemberExpression)
+            if (exp.Arguments.LastOrDefault() is MemberExpression && exp.Arguments.FirstOrDefault() is MemberExpression)
             {
                 var propertyExpression = (MemberExpression)exp.Arguments.Last();
                 var valuesExpression = (MemberExpression)exp.Arguments.First();
@@ -643,6 +638,11 @@ namespace Redis.OM.Common
                 ret = ret.Substring(0, ret.Length - 1);
 
                 return ret;
+            }
+
+            if (exp.Object is MemberExpression)
+            {
+                expression = exp.Object as MemberExpression;
             }
             else if (exp.Arguments.FirstOrDefault() is MemberExpression)
             {

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -588,7 +588,7 @@ namespace Redis.OM.Common
             Type type;
             string memberName;
             string literal;
-            if (exp.Object is MemberExpression && exp.Object.ToString().Contains("x."))
+            if (exp.Object is MemberExpression && exp.Object.ToString().StartsWith("x."))
             {
                 expression = exp.Object as MemberExpression;
             }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -966,5 +966,22 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var countPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList().Count;
             Assert.Equal(people.Count, countPeople);
         }
+
+        [Fact]
+        public async Task TestContainsList()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var person1 = new Person() { Name = "Ferb", Age = 14, NickNames = new[] { "Feb", "Fee" } };
+            var person2 = new Person() { Name = "Phineas", Age = 14, NickNames = new[] { "Phineas", "Triangle Head", "Phine" } };
+
+            await collection.InsertAsync(person1);
+            await collection.InsertAsync(person2);
+
+            var names = new List<string> { "Ferb", "Phineas" };
+            var people = await collection.Where(x => names.Contains(x.Name)).ToListAsync();
+
+            Assert.Contains(people, x => x.Id == person1.Id);
+            Assert.Contains(people, x => x.Id == person2.Id);
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -968,7 +968,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestContainsList()
+        public async Task TestListContains()
         {
             var collection = new RedisCollection<Person>(_connection);
             var person1 = new Person() { Name = "Ferb", Age = 14, NickNames = new[] { "Feb", "Fee" } };
@@ -979,6 +979,24 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             var names = new List<string> { "Ferb", "Phineas" };
             var people = await collection.Where(x => names.Contains(x.Name)).ToListAsync();
+
+            Assert.Contains(people, x => x.Id == person1.Id);
+            Assert.Contains(people, x => x.Id == person2.Id);
+        }
+
+        [Fact]
+        public async Task TestListMultipleContains()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var person1 = new Person() { Name = "Ferb", Age = 14, NickNames = new[] { "Feb", "Fee" }, TagField = "Ferb"  };
+            var person2 = new Person() { Name = "Phineas", Age = 14, NickNames = new[] { "Phineas", "Triangle Head", "Phine" }, TagField = "Phineas" };
+
+            await collection.InsertAsync(person1);
+            await collection.InsertAsync(person2);
+
+            var names = new List<string> { "Ferb", "Phineas" };
+            var ages = new List<int?> { 14, 50, 60 };
+            var people = await collection.Where(x => names.Contains(x.Name) && names.Contains(x.TagField) && ages.Contains(x.Age)).ToListAsync();
 
             Assert.Contains(people, x => x.Id == person1.Id);
             Assert.Contains(people, x => x.Id == person2.Id);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2482,7 +2482,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void SearchNumericFieldContainsList()
+        public void SearchNumericFieldListContains()
         {
             var potentialTagFieldValues = new List<int?> { 35, 50, 60 };
             _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
@@ -2499,17 +2499,17 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void SearchTagFieldContainsList()
+        public void SearchTagFieldAndTextListContains()
         {
             var potentialTagFieldValues = new List<string> { "Steve", "Alice", "Bob" };
             _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
                 .Returns(_mockReply);
-            var collection = new RedisCollection<Person>(_mock.Object).Where(x => potentialTagFieldValues.Contains(x.TagField));
+            var collection = new RedisCollection<Person>(_mock.Object).Where(x => potentialTagFieldValues.Contains(x.TagField) || potentialTagFieldValues.Contains(x.Name));
             collection.ToList();
             _mock.Verify(x => x.Execute(
                 "FT.SEARCH",
                 "person-idx",
-                "(@TagField:{Steve|Alice|Bob})",
+                "((@TagField:{Steve|Alice|Bob}) | (@Name:Steve|Alice|Bob))",
                 "LIMIT",
                 "0",
                 "100"));

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2514,5 +2514,22 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100"));
         }
+        
+        [Fact]
+        public void SearchTagFieldAndTextListContainsWithEscapes()
+        {
+            var potentialTagFieldValues = new List<string> { "steve@example.com", "alice@example.com", "bob@example.com" };
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisCollection<Person>(_mock.Object).Where(x => potentialTagFieldValues.Contains(x.TagField) || potentialTagFieldValues.Contains(x.Name));
+            collection.ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "((@TagField:{steve\\@example\\.com|alice\\@example\\.com|bob\\@example\\.com}) | (@Name:steve@example.com|alice@example.com|bob@example.com))",
+                "LIMIT",
+                "0",
+                "100"));
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2480,5 +2480,39 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "1000"
             ));
         }
+
+        [Fact]
+        public void SearchNumericFieldContainsList()
+        {
+            var potentialTagFieldValues = new List<int?> { 35, 50, 60 };
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisCollection<Person>(_mock.Object).Where(x => potentialTagFieldValues.Contains(x.Age));
+            collection.ToList();
+            _mock.Verify(x => x.Execute(
+               "FT.SEARCH",
+               "person-idx",
+               "@Age:[35 35]|@Age:[50 50]|@Age:[60 60]",
+               "LIMIT",
+               "0",
+               "100"));
+        }
+
+        [Fact]
+        public void SearchTagFieldContainsList()
+        {
+            var potentialTagFieldValues = new List<string> { "Steve", "Alice", "Bob" };
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisCollection<Person>(_mock.Object).Where(x => potentialTagFieldValues.Contains(x.TagField));
+            collection.ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@TagField:{Steve|Alice|Bob})",
+                "LIMIT",
+                "0",
+                "100"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #203, issue with `List` type queries the expression object not parsing inverted contains. 