### PR TITLE
Adding Any method without arguments to IRedisCollection

### DIFF
--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -84,6 +84,12 @@ namespace Redis.OM.Searching
         T? FindById(string id);
 
         /// <summary>
+        /// Checks to see if the collection contains any.
+        /// </summary>
+        /// <returns>Whether anything matching the expression was found.</returns>
+        bool Any();
+
+        /// <summary>
         /// Checks to see if anything matching the expression exists.
         /// </summary>
         /// <param name="expression">the expression to be matched.</param>

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -113,6 +113,14 @@ namespace Redis.OM.Searching
             }
         }
 
+        /// <inheritdoc />
+        public bool Any()
+        {
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T), BooleanExpression);
+            query.Limit = new SearchLimit { Number = 0, Offset = 0 };
+            return (int)_connection.Search<T>(query).DocumentCount > 0;
+        }
+
         /// <summary>
         /// Checks to see if anything matching the expression exists.
         /// </summary>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2531,5 +2531,33 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100"));
         }
+
+        [Fact]
+        public void SearchWithEmptyAny()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var any = collection.Any();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "*",
+                "LIMIT",
+                "0",
+                "0"));
+            Assert.True(any);
+
+            any = collection.Where(x => x.TagField == "foo").Any();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@TagField:{foo})",
+                "LIMIT",
+                "0",
+                "0"));
+            
+            Assert.True(any);
+        }
     }
 }


### PR DESCRIPTION
Fixes #243 - forgot to add `Any()` to IRedisColleciton, so it defaulted to the Query Providers Execute method.