### PR TITLE
forcing reload on scripting error, using correct sha in some tests

### DIFF
--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.4.0</PackageVersion>
-    <Version>0.4.0</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.4.0</PackageReleaseNotes>
+    <PackageVersion>0.4.1</PackageVersion>
+    <Version>0.4.1</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.4.1</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2581,5 +2581,33 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100"));
         }
+
+        [Fact]
+        public void SearchWithEmptyAny()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var any = collection.Any();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "*",
+                "LIMIT",
+                "0",
+                "0"));
+            Assert.True(any);
+
+            any = collection.Where(x => x.TagField == "foo").Any();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@TagField:{foo})",
+                "LIMIT",
+                "0",
+                "0"));
+
+            Assert.True(any);
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -773,12 +773,46 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _mock.Setup(x => x.Execute("FT.SEARCH", It.IsAny<string[]>()))
                 .Returns(_mockReply);
             _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
-            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("cbbf1c4fab5064f419e469cc51c563f8bf51e6fb");
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Age = 33;
             await collection.UpdateAsync(steve);
-            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "42", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
+            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "cbbf1c4fab5064f419e469cc51c563f8bf51e6fb", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
+            Scripts.ShaCollection.Clear();
+        }
+
+        [Fact]
+        public async Task TestUpdateJsonUnloadedScriptAsync()
+        {
+            _mock.Setup(x => x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).Throws(new RedisServerException("Failed on EVALSHA"));
+            _mock.Setup(x => x.ExecuteAsync("EVAL", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("cbbf1c4fab5064f419e469cc51c563f8bf51e6fb");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Age = 33;
+            await collection.UpdateAsync(steve);
+            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "cbbf1c4fab5064f419e469cc51c563f8bf51e6fb", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
+            _mock.Verify(x => x.ExecuteAsync("EVAL",Scripts.JsonDiffResolution, "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
+            Scripts.ShaCollection.Clear();
+        }
+
+        [Fact]
+        public void TestUpdateJsonUnloadedScript()
+        {
+            _mock.Setup(x => x.Execute("FT.SEARCH", It.IsAny<string[]>()))
+                .Returns(_mockReply);
+            _mock.Setup(x => x.Execute("EVALSHA", It.IsAny<string[]>())).Throws(new RedisServerException("Failed on EVALSHA"));
+            _mock.Setup(x => x.Execute("EVAL", It.IsAny<string[]>())).Returns("42");
+            _mock.Setup(x => x.Execute("SCRIPT", It.IsAny<string[]>())).Returns("cbbf1c4fab5064f419e469cc51c563f8bf51e6fb");
+            var collection = new RedisCollection<Person>(_mock.Object);
+            var steve = collection.First(x => x.Name == "Steve");
+            steve.Age = 33;
+            collection.Update(steve);
+            _mock.Verify(x => x.Execute("EVALSHA", "cbbf1c4fab5064f419e469cc51c563f8bf51e6fb", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
+            _mock.Verify(x => x.Execute("EVAL",Scripts.JsonDiffResolution, "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Age", "33"));
             Scripts.ShaCollection.Clear();
         }
 
@@ -803,18 +837,18 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _mock.Setup(x => x.Execute("FT.SEARCH", It.IsAny<string[]>()))
                 .Returns(_mockReply);
             _mock.Setup(x => x.ExecuteAsync("EVALSHA", It.IsAny<string[]>())).ReturnsAsync("42");
-            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("42");
+            _mock.Setup(x => x.ExecuteAsync("SCRIPT", It.IsAny<string[]>())).ReturnsAsync("cbbf1c4fab5064f419e469cc51c563f8bf51e6fb");
             var collection = new RedisCollection<Person>(_mock.Object);
             var steve = collection.First(x => x.Name == "Steve");
             steve.Address = new Address { State = "Florida" };
             await collection.UpdateAsync(steve);
             var expected = $"{{{Environment.NewLine}  \"State\": \"Florida\"{Environment.NewLine}}}";
-            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "42", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Address", expected));
+            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "cbbf1c4fab5064f419e469cc51c563f8bf51e6fb", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Address", expected));
 
             steve.Address.City = "Satellite Beach";
             await collection.UpdateAsync(steve);
             expected = "\"Satellite Beach\"";
-            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "42", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Address.City", expected));
+            _mock.Verify(x => x.ExecuteAsync("EVALSHA", "cbbf1c4fab5064f419e469cc51c563f8bf51e6fb", "1", "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N", "SET", "$.Address.City", expected));
 
             Scripts.ShaCollection.Clear();
         }
@@ -2546,34 +2580,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "LIMIT",
                 "0",
                 "100"));
-        }
-
-        [Fact]
-        public void SearchWithEmptyAny()
-        {
-            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
-                .Returns(_mockReply);
-            var collection = new RedisCollection<Person>(_mock.Object);
-            var any = collection.Any();
-            _mock.Verify(x => x.Execute(
-                "FT.SEARCH",
-                "person-idx",
-                "*",
-                "LIMIT",
-                "0",
-                "0"));
-            Assert.True(any);
-
-            any = collection.Where(x => x.TagField == "foo").Any();
-            _mock.Verify(x => x.Execute(
-                "FT.SEARCH",
-                "person-idx",
-                "(@TagField:{foo})",
-                "LIMIT",
-                "0",
-                "0"));
-            
-            Assert.True(any);
         }
     }
 }


### PR DESCRIPTION
Fixes #272 - issue is when redis is rolled over, the client's not properly handling the reload and trying to send `EVALSHA`'s when it really needs to either run an `EVAL` or script reload. Because At this point in the error flow we are already one or two round trips to redis in, we'll use an `EVAL` for the initial condition, and empty out our collection of SHA's so that we force the client to reload all scripts it was previously running