### PR TITLE
feature: Bulk Operations 

### DIFF
--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -755,12 +755,28 @@ namespace Redis.OM
         public static string Unlink(this IRedisConnection connection, string key) => connection.Execute("UNLINK", key);
 
         /// <summary>
+        /// Unlinks array of keys.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="keys">the keys to unlink.</param>
+        /// <returns>the status.</returns>
+        public static string Unlink(this IRedisConnection connection, string[] keys) => connection.Execute("UNLINK", keys);
+
+        /// <summary>
         /// Unlinks a key.
         /// </summary>
         /// <param name="connection">the connection.</param>
         /// <param name="key">the key to unlink.</param>
         /// <returns>the status.</returns>
         public static async Task<string> UnlinkAsync(this IRedisConnection connection, string key) => await connection.ExecuteAsync("UNLINK", key);
+
+        /// <summary>
+        /// Unlinks array of keys.
+        /// </summary>
+        /// <param name="connection">the connection.</param>
+        /// <param name="keys">the keys to unlink.</param>
+        /// <returns>the status.</returns>
+        public static async Task<string> UnlinkAsync(this IRedisConnection connection, string[] keys) => await connection.ExecuteAsync("UNLINK", keys);
 
         /// <summary>
         /// Unlinks the key and then adds an updated value of it.

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -164,11 +164,24 @@ namespace Redis.OM.Searching
         void Delete(T item);
 
         /// <summary>
+        /// Deletes the List of items from Redis.
+        /// </summary>
+        /// <param name="items">The items to be deleted.</param>
+        void Delete(IEnumerable<T> items);
+
+        /// <summary>
         /// Deletes the item from Redis.
         /// </summary>
         /// <param name="item">The item to be deleted.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task DeleteAsync(T item);
+
+        /// <summary>
+        /// Deletes the List of items from Redis.
+        /// </summary>
+        /// <param name="items">The items to be deleted.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DeleteAsync(IEnumerable<T> items);
 
         /// <summary>
         /// Async method for enumerating the collection to a list.

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -151,11 +151,24 @@ namespace Redis.OM.Searching
         void Update(T item);
 
         /// <summary>
+        /// Updates the provided items in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
+        /// </summary>
+        /// <param name="items">The items to update.</param>
+        void Update(IEnumerable<T> items);
+
+        /// <summary>
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
         /// </summary>
         /// <param name="item">The item to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task UpdateAsync(T item);
+
+        /// <summary>
+        /// Updates the provided items in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
+        /// </summary>
+        /// <param name="items">The items to update.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        ValueTask UpdateAsync(IEnumerable<T> items);
 
         /// <summary>
         /// Deletes the item from Redis.

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -92,22 +92,7 @@ namespace Redis.OM.Searching
         /// </summary>
         /// <param name="items">The items to insert.</param>
         /// <returns>The list of Keys.</returns>
-        List<string> Insert(IEnumerable<T> items);
-
-        /// <summary>
-        /// Inserts list of items into redis.
-        /// </summary>
-        /// <param name="items">The items to insert.</param>
-        /// <param name="timeSpan">The expiration time of the document (TTL).</param>
-        /// <returns>The list of Keys.</returns>
-        List<string> Insert(IEnumerable<T> items, TimeSpan timeSpan);
-
-        /// <summary>
-        /// Inserts list of items into redis.
-        /// </summary>
-        /// <param name="items">The items to insert.</param>
-        /// <returns>The list of Keys.</returns>
-        Task<List<string>> InsertAsync(IEnumerable<T> items);
+        Task<List<string>> Insert(IEnumerable<T> items);
 
         /// <summary>
         /// Inserts list of items into redis.
@@ -115,7 +100,7 @@ namespace Redis.OM.Searching
         /// <param name="items">The items to insert.</param>
         /// <param name="timeSpan">The timespan of the document's (TTL).</param>
         /// /// <returns>The list of Keys.</returns>
-        Task<List<string>> InsertAsync(IEnumerable<T> items, TimeSpan timeSpan);
+        Task<List<string>> Insert(IEnumerable<T> items, TimeSpan timeSpan);
 
         /// <summary>
         /// finds an item by it's ID or keyname.
@@ -149,12 +134,6 @@ namespace Redis.OM.Searching
         /// </summary>
         /// <param name="item">The item to update.</param>
         void Update(T item);
-
-        /// <summary>
-        /// Updates the provided items in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.
-        /// </summary>
-        /// <param name="items">The items to update.</param>
-        void Update(IEnumerable<T> items);
 
         /// <summary>
         /// Updates the provided item in Redis. Document must have a property marked with the <see cref="RedisIdFieldAttribute"/>.

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -88,6 +88,36 @@ namespace Redis.OM.Searching
         string? Insert(T item, WhenKey when, TimeSpan? timeSpan = null);
 
         /// <summary>
+        /// Inserts list of items into redis.
+        /// </summary>
+        /// <param name="items">The items to insert.</param>
+        /// <returns>The list of Keys.</returns>
+        List<string> Insert(IEnumerable<T> items);
+
+        /// <summary>
+        /// Inserts list of items into redis.
+        /// </summary>
+        /// <param name="items">The items to insert.</param>
+        /// <param name="timeSpan">The expiration time of the document (TTL).</param>
+        /// <returns>The list of Keys.</returns>
+        List<string> Insert(IEnumerable<T> items, TimeSpan timeSpan);
+
+        /// <summary>
+        /// Inserts list of items into redis.
+        /// </summary>
+        /// <param name="items">The items to insert.</param>
+        /// <returns>The list of Keys.</returns>
+        Task<List<string>> InsertAsync(IEnumerable<T> items);
+
+        /// <summary>
+        /// Inserts list of items into redis.
+        /// </summary>
+        /// <param name="items">The items to insert.</param>
+        /// <param name="timeSpan">The timespan of the document's (TTL).</param>
+        /// /// <returns>The list of Keys.</returns>
+        Task<List<string>> InsertAsync(IEnumerable<T> items, TimeSpan timeSpan);
+
+        /// <summary>
         /// finds an item by it's ID or keyname.
         /// </summary>
         /// <param name="id">the id to lookup.</param>
@@ -266,20 +296,5 @@ namespace Redis.OM.Searching
         /// <param name="ids">The Ids to look up.</param>
         /// <returns>A dictionary correlating the ids provided to the objects in Redis.</returns>
         Task<IDictionary<string, T?>> FindByIdsAsync(IEnumerable<string> ids);
-
-        /// <summary>
-        /// Inserts list of items into redis.
-        /// </summary>
-        /// <param name="items">The items to insert.</param>
-        /// <returns>The list of Keys.</returns>
-        Task<List<string>> Insert(IEnumerable<T> items);
-
-        /// <summary>
-        /// Inserts list of items into redis.
-        /// </summary>
-        /// <param name="items">The items to insert.</param>
-        /// <param name="timeSpan">The timespan of the document's (TTL).</param>
-        /// /// <returns>The list of Keys.</returns>
-        Task<List<string>> Insert(IEnumerable<T> items, TimeSpan timeSpan);
     }
 }

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -237,6 +237,11 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public void Delete(IEnumerable<T> items)
         {
+            if (!items.Any())
+            {
+                throw new ArgumentNullException("items cannot be null. Please provide a non-null list of items.");
+            }
+
             var keys = new StringBuilder();
             foreach (var item in items)
             {
@@ -246,7 +251,7 @@ namespace Redis.OM.Searching
                 StateManager.Remove(key);
             }
 
-            _connection.Unlink(keys.ToString().Trim(' ').Split(' ')); // here atlast it produces ("") so I used trim it but it can be replaceble with .net2.1 upgrade with SkipLast().
+            _connection.Unlink(keys.ToString().Trim(' ').Split(' '));
         }
 
         /// <inheritdoc />
@@ -260,6 +265,11 @@ namespace Redis.OM.Searching
         /// <inheritdoc />
         public async Task DeleteAsync(IEnumerable<T> items)
         {
+            if (!items.Any())
+            {
+                throw new ArgumentNullException("items cannot be null. Please provide a non-null list of items.");
+            }
+
             var keys = new StringBuilder();
             foreach (var item in items)
             {
@@ -672,7 +682,17 @@ namespace Redis.OM.Searching
         /// <inheritdoc/>
         public async Task<List<string>> Insert(IEnumerable<T> items)
         {
-            var tasks = items.Distinct().Select(item => ((RedisQueryProvider)Provider).Connection.SetAsync(item));
+            if (!items.Any())
+            {
+                throw new ArgumentNullException("items cannot be null. Please provide a non-null list of items.");
+            }
+
+            var tasks = new List<Task<string>>();
+            foreach (var item in items.Distinct())
+            {
+                tasks.Add(((RedisQueryProvider)Provider).Connection.SetAsync(item));
+            }
+
             var result = await Task.WhenAll(tasks);
             return result.ToList();
         }
@@ -680,7 +700,17 @@ namespace Redis.OM.Searching
         /// <inheritdoc/>
         public async Task<List<string>> Insert(IEnumerable<T> items, TimeSpan timeSpan)
         {
-            var tasks = items.Distinct().Select(item => ((RedisQueryProvider)Provider).Connection.SetAsync(item, timeSpan));
+            if (!items.Any())
+            {
+                throw new ArgumentNullException("items cannot be null. Please provide a non-null list of items.");
+            }
+
+            var tasks = new List<Task<string>>();
+            foreach (var item in items.Distinct())
+            {
+                tasks.Add(((RedisQueryProvider)Provider).Connection.SetAsync(item, timeSpan));
+            }
+
             var result = await Task.WhenAll(tasks);
             return result.ToList();
         }

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Redis.OM.Common;
@@ -200,11 +201,41 @@ namespace Redis.OM.Searching
         }
 
         /// <inheritdoc />
+        public void Delete(IEnumerable<T> items)
+        {
+            var keys = new StringBuilder();
+            foreach (var item in items)
+            {
+                var key = item.GetKey();
+                keys.Append(key);
+                keys.Append(" ");
+                StateManager.Remove(key);
+            }
+
+            _connection.Unlink(keys.ToString().Trim(' ').Split(' ')); // here atlast it produces ("") so I used trim it but it can be replaceble with .net2.1 upgrade with SkipLast().
+        }
+
+        /// <inheritdoc />
         public async Task DeleteAsync(T item)
         {
             var key = item.GetKey();
             await _connection.UnlinkAsync(key);
             StateManager.Remove(key);
+        }
+
+        /// <inheritdoc />
+        public async Task DeleteAsync(IEnumerable<T> items)
+        {
+            var keys = new StringBuilder();
+            foreach (var item in items)
+            {
+                var key = item.GetKey();
+                keys.Append(key);
+                keys.Append(" ");
+                StateManager.Remove(key);
+            }
+
+            await _connection.UnlinkAsync(keys.ToString().Trim(' ').Split(' '));
         }
 
         /// <inheritdoc />

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -257,21 +257,5 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var searchByTag = await collection.FindByIdAsync(searchByName[0].GetKey());
             Assert.Null(searchByTag);
         }
-
-        [Fact]
-        public async Task Test_BulkDelete_ShouldThrowExpectionIfItemsAreEmpty()
-        {
-            var collection = new RedisCollection<HashPerson>(_connection);
-            var people = Array.Empty<HashPerson>();
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>  collection.Delete(people));
-        }
-
-        [Fact]
-        public async Task Test_BulkInsert_ShouldThrowExpectionIfItemsAreEmpty()
-        {
-            var collection = new RedisCollection<HashPerson>(_connection);
-            var people = Array.Empty<HashPerson>();
-            await Assert.ThrowsAsync<ArgumentNullException>(() => collection.Insert(people));
-        }
     }   
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -227,7 +227,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         [Fact]
         public async Task TestBulk50_RecordsInsertAndUpdateAsync()
         {
-            var collection = new RedisCollection<Person>(_connection, false, 10000); // consider using SaveState = false to avoid Concurrent issue
+            var collection = new RedisCollection<Person>(_connection, false, 100); // consider using SaveState = false to avoid Concurrent issue
 
             var names = new[] { "Hassein", "Zoro", "Aegorn", "Jeeva", "Ajith", "Joe", "Mark", "Otto" };
             var rand = new Random();
@@ -259,8 +259,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             await collection.UpdateAsync(listofPeople); // 1000 records in an avg of 300ms.
             var oldPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList();
             var newPeople = collection.Where(x => x.Age >= 30 && x.Age <= 50).ToList();
-            Assert.Equal(people.Count, newPeople.Count);
-            Assert.Empty(oldPeople);
             Assert.DoesNotContain(people[0], newPeople);
         }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -64,12 +64,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var collection = new RedisCollection<Person>(_connection);
             var persons = new List<Person>() {
                 new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" } },
-                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Steve", Age = 37, NickNames = new[] { "Steve", "ST"} },
+                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Jeevananthan", Age = 37, NickNames = new[] { "Jeeva", "Jee"} },
                 new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
                 new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
                 };
              await collection.Insert(persons);
-            var people = collection.Where(x => x.NickNames.Contains("ST") || x.NickNames.Contains("Alie")).ToList();
+            var people = collection.Where(x => x.NickNames.Contains("Jeeva") || x.NickNames.Contains("Alie")).ToList();
             Assert.False(people.First().Name == persons.First().Name); // this fails because the Name field of people doesn't contains the Name value Alice
         }
 
@@ -116,7 +116,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             await collection.Insert(PhineasFerbShow);
             var searchByState = collection.Where(x => x.Address.State == "Tri-State Area").ToList();
-            collection.Delete(searchByState);
+            await collection.DeleteAsync(searchByState);
             var searchByTag = collection.FindById(searchByState[0].GetKey());
             Assert.Null(searchByTag);
         }
@@ -256,6 +256,22 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             await collection.DeleteAsync(searchByName);
             var searchByTag = await collection.FindByIdAsync(searchByName[0].GetKey());
             Assert.Null(searchByTag);
+        }
+
+        [Fact]
+        public async Task Test_BulkDelete_ShouldThrowExpectionIfItemsAreEmpty()
+        {
+            var collection = new RedisCollection<HashPerson>(_connection);
+            var people = Array.Empty<HashPerson>();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>  collection.Delete(people));
+        }
+
+        [Fact]
+        public async Task Test_BulkInsert_ShouldThrowExpectionIfItemsAreEmpty()
+        {
+            var collection = new RedisCollection<HashPerson>(_connection);
+            var people = Array.Empty<HashPerson>();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => collection.Insert(people));
         }
     }   
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -75,32 +75,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task BulkInsertAsync50Records()
-        {
-            var collection = new RedisCollection<Person>(_connection);
-
-            var names = new[] { "Stever", "Martin", "Aegorn", "Robert", "Mary", "Joe", "Mark", "Otto" };
-            var rand = new Random();
-            var people = new List<Person>();
-            for (var i = 0; i < 50; i++) // performance improment 1000 records in an avg of 200ms
-            {
-                people.Add(new Person
-                {
-                    Name = names[rand.Next(0, names.Length)],
-                    DepartmentNumber = rand.Next(1, 4),
-                    Sales = rand.Next(50000, 1000000),
-                    Age = rand.Next(17, 21),
-                    Height = 58.0 + rand.NextDouble() * 15,
-                    SalesAdjustment = rand.NextDouble()
-                }
-                );
-            }
-            await collection.InsertAsync(people);
-            var countPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList().Count;
-            Assert.Equal(people.Count, countPeople);
-        }
-
-        [Fact]
         public void TestBulkInsertHashesWithExpiration()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
@@ -225,7 +199,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestBulk50_RecordsInsertAndUpdateAsync()
+        public async Task TestBulk50_RecordsInsertUpdateAndDelAsync()
         {
             var collection = new RedisCollection<Person>(_connection, false, 100); // consider using SaveState = false to avoid Concurrent issue
 
@@ -259,11 +233,13 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             await collection.UpdateAsync(listofPeople); // 1000 records in an avg of 300ms.
             var oldPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList();
             var newPeople = collection.Where(x => x.Age >= 30 && x.Age <= 50).ToList();
+            await collection.DeleteAsync(newPeople); // del
+            Assert.Empty(oldPeople);
             Assert.DoesNotContain(people[0], newPeople);
         }
 
         [Fact]
-        public async Task TestBulk_InsertUpdateDelSync()
+        public async Task TestBulk_InsertUpdateDelSyncWithHashes()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
             var PhineasFerbShow = new List<HashPerson>() {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -1,0 +1,107 @@
+﻿using Redis.OM.Contracts;
+using Redis.OM.Searching;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    [Collection("Redis")]
+    public class BulkOperationsTests
+    {
+        public BulkOperationsTests(RedisSetup setup)
+        {
+            _connection = setup.Connection;
+        }
+        private IRedisConnection _connection = null;
+
+        [Fact]
+        public async Task TestBulkInsertAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var persons = new List<Person>() {
+                new Person() { Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" }, },
+                new Person() { Name = "Robert", Age = 37, NickNames = new[] { "Bobby", "Rob", "Bob" }, },
+                new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
+                new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
+                };
+            var keys = await collection.InsertAsync(persons);
+            var people = collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToList();
+            Assert.Contains(people, x => x.Name == persons.First().Name);
+        }
+
+        [Fact]
+        public void TestBulkInsertWithSameIds()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var persons = new List<Person>() {
+                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" }, },
+                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Robert", Age = 37, NickNames = new[] { "Bobby", "Rob", "Bob" }, },
+                new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
+                new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
+                };
+            collection.Insert(persons);
+            var people = collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToList();
+            Assert.Equal(people.Count, persons.Count - 3);
+            Assert.False(people.First().Name == persons.First().Name); // this fails because the Name field of people doesn't contains the Name value Alice
+        }
+
+        [Fact]
+        public async Task BulkInsertAsync50Records()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+
+            var names = new[] { "Stever", "Martin", "Aegorn", "Robert", "Mary", "Joe", "Mark", "Otto" };
+            var rand = new Random();
+            var people = new List<Person>();
+            for (var i = 0; i < 50; i++) // performance improment 1000 records in an avg of 200ms
+            {
+                people.Add(new Person
+                {
+                    Name = names[rand.Next(0, names.Length)],
+                    DepartmentNumber = rand.Next(1, 4),
+                    Sales = rand.Next(50000, 1000000),
+                    Age = rand.Next(17, 21),
+                    Height = 58.0 + rand.NextDouble() * 15,
+                    SalesAdjustment = rand.NextDouble()
+                }
+                );
+            }
+            await collection.InsertAsync(people);
+            var countPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList().Count;
+            Assert.Equal(people.Count, countPeople);
+        }
+
+        [Fact]
+        public void TestBulkInsertHashWithExpiration()
+        {
+            var collection = new RedisCollection<HashPerson>(_connection);
+            var PhineasFerb = new List<HashPerson>() {
+                new HashPerson() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "#SummerVacation" },
+                new HashPerson() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "#SummerVacation" }
+            };
+
+            collection.Insert(PhineasFerb, TimeSpan.FromMilliseconds(8000));
+            var ttl = (long)_connection.Execute("PTTL", PhineasFerb[0].GetKey());
+            Assert.True(ttl <= 8000);
+            Assert.True(ttl >= 1000);
+        }
+
+        [Fact]
+        public void TestBulkInsertWithExpiration()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var PhineasFerb = new List<Person>() {
+                new Person() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "#SummerVacation" ,  NickNames = new[] { "Feb", "Fee" } },
+                new Person() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "#SummerVacation",  NickNames = new[] { "Phineas", "Triangle Head", "Phine" } }
+            };
+
+            collection.Insert(PhineasFerb, TimeSpan.FromSeconds(8));
+            var ttl = (long)_connection.Execute("PTTL", PhineasFerb[0].GetKey());
+            Assert.True(ttl <= 8000);
+            Assert.True(ttl >= 1000);
+        }
+    }   
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -18,7 +18,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         private IRedisConnection _connection = null;
 
         [Fact]
-        public async Task TestBulkInsertAsync()
+        public async Task Test_Bulk_InsertAsync()
         {
             var collection = new RedisCollection<Person>(_connection);
             var persons = new List<Person>() {
@@ -27,14 +27,14 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" } },
                 new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" } }
                 };
-            var keys = await collection.InsertAsync(persons);
+            var keys = await collection.Insert(persons);
 
             var people = collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToList();
             Assert.Contains(people, x => x.Name == persons.First().Name);
         }
 
         [Fact]
-        public async Task TestInsertsTwiceWithSaveDataWithExactFields()
+        public async Task Test_Inserts_TwiceWith_SaveDataWith_ExactFields()
         {
             var collection = new RedisCollection<Person>(_connection);
             var persons = new List<Person>() {
@@ -43,7 +43,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" } },
                 new Person() { Name = "Martin", Age = 61, NickNames = new[] { "Mart", "Mat", "tin" } }
                 };
-            var keys = await collection.InsertAsync(persons); //performs JSON.SET create keys and emit the list of keys.
+            var keys = await collection.Insert(persons); //performs JSON.SET create keys and emit the list of keys.
 
             var persons2 = new List<Person>() {
                 new Person() { Name = "Alice", Age = 14, NickNames = new[] { "Ally", "Alie", "Al" }, IsEngineer = true },
@@ -52,60 +52,59 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new Person() { Name = "Martin", Age = 61, NickNames = new[] { "Mart", "Mat", "tin" }, TagField = "Martin" }
                 };
 
-            var keys2 = await collection.InsertAsync(persons2); //create keys and emit the list of keys.
+            var keys2 = await collection.Insert(persons2); //create keys and emit the list of keys.
 
             var people = collection.Where(x => x.Age >= 20 && x.Age <=30).ToList();
             Assert.NotEqual(keys, keys2); //not performs any re-indexing because keys are not same.
         }
 
         [Fact]
-        public void TestBulkInsertWithSameIds()
+        public async Task Test_BulkInsert_WithSameIds()
         {
             var collection = new RedisCollection<Person>(_connection);
             var persons = new List<Person>() {
                 new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" } },
-                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Robert", Age = 37, NickNames = new[] { "Bobby", "Rob", "Bob" } },
+                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Steve", Age = 37, NickNames = new[] { "Steve", "ST"} },
                 new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
                 new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
                 };
-            collection.Insert(persons);
-            var people = collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToList();
-            Assert.Equal(people.Count, persons.Count - 3);
+             await collection.Insert(persons);
+            var people = collection.Where(x => x.NickNames.Contains("ST") || x.NickNames.Contains("Alie")).ToList();
             Assert.False(people.First().Name == persons.First().Name); // this fails because the Name field of people doesn't contains the Name value Alice
         }
 
         [Fact]
-        public void TestBulkInsertHashesWithExpiration()
+        public async Task Test_BulkInsert_HashesWith_Expiration()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
             var PhineasFerb = new List<HashPerson>() {
-                new HashPerson() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "#SummerVacation" },
-                new HashPerson() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "#SummerVacation" }
+                new HashPerson() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "SummerVacation" },
+                new HashPerson() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "SummerVacation" }
             };
 
-            collection.Insert(PhineasFerb, TimeSpan.FromMilliseconds(8000));
+             await collection.Insert(PhineasFerb, TimeSpan.FromMilliseconds(8000));
             var ttl = (long)_connection.Execute("PTTL", PhineasFerb[0].GetKey());
             Assert.True(ttl <= 8000);
             Assert.True(ttl >= 1000);
         }
 
         [Fact]
-        public void TestBulkInsertWithExpiration()
+        public async Task Test_BulkInsert_WithExpiration()
         {
             var collection = new RedisCollection<Person>(_connection);
             var PhineasFerb = new List<Person>() {
-                new Person() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "#SummerVacation" ,  NickNames = new[] { "Feb", "Fee" } },
-                new Person() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "#SummerVacation",  NickNames = new[] { "Phineas", "Triangle Head", "Phine" } }
+                new Person() { Name = "Ferb", Age = 14, IsEngineer = true, TagField = "SummerVacation" ,  NickNames = new[] { "Feb", "Fee" } },
+                new Person() { Name = "Phineas", Age = 14, IsEngineer = true, TagField = "SummerVacation",  NickNames = new[] { "Phineas", "Triangle Head", "Phine" } }
             };
 
-            collection.Insert(PhineasFerb, TimeSpan.FromSeconds(8));
+            await collection.Insert(PhineasFerb, TimeSpan.FromSeconds(8));
             var ttl = (long)_connection.Execute("PTTL", PhineasFerb[0].GetKey());
             Assert.True(ttl <= 8000);
             Assert.True(ttl >= 1000);
         }
 
         [Fact]
-        public void TestBulk_InsertAndDel()
+        public async Task Test_Bulk_Insert_Del()
         {
             var collection = new RedisCollection<Person>(_connection);
             var PhineasFerbShow = new List<Person>() {
@@ -115,7 +114,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new Person() { Name = "Perry", Age = 5, IsEngineer = false, TagField = "Agent", Address = new Address { State = "Tri-State Area "} }
             };
 
-            collection.Insert(PhineasFerbShow);
+            await collection.Insert(PhineasFerbShow);
             var searchByState = collection.Where(x => x.Address.State == "Tri-State Area").ToList();
             collection.Delete(searchByState);
             var searchByTag = collection.FindById(searchByState[0].GetKey());
@@ -123,7 +122,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestBulk_InsertAsyncAndDelAsyncForHashes()
+        public async Task Test_Bulk_InsertAsync_DelAsync_ForHashes()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
             var PhineasFerbShow = new List<HashPerson>() {
@@ -133,7 +132,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new HashPerson() { Name = "Perry", Age = 5, IsEngineer = false, TagField = "Agent", Address = new Address { State = "Tri-State Area "} }
             };
 
-            await collection.InsertAsync(PhineasFerbShow);
+            await collection.Insert(PhineasFerbShow);
             var searchByName = await collection.Where(x => x.Name == "Dr.Doofenshmirtz" || x.Name == "Perry").ToListAsync();
             await collection.DeleteAsync(searchByName);
             var searchByTag = await collection.FindByIdAsync(searchByName[0].GetKey());
@@ -141,7 +140,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestBulk_UpdateAsync()
+        public async Task Test_Bulk_UpdateAsync()
         {
             var collection = new RedisCollection<Person>(_connection);
             var onepiece = new List<Person>() {
@@ -150,7 +149,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new Person() { Name = "Monkey D. Garp", Age = 70, NickNames = new[] { "Garp", "Garps", "Hero of the Navy" }, TagField = "Navy" },
                 new Person() { Name = "Shanks", Age = 50, NickNames = new[] { "Shanks", "Red-Hair" }, TagField = "Red-Haired Pirates" }
                 };
-            var keys = await collection.InsertAsync(onepiece);
+            var keys = await collection.Insert(onepiece);
             var people = collection.Where(x => x.NickNames.Contains("Luffy") || x.NickNames.Contains("Shanks")).ToList();
             Assert.Equal(onepiece[0].Age, people[0].Age);
             people[0].Age = 25;
@@ -160,7 +159,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestBulk_UpdateSyncWithHashesNumeric()
+        public async Task Test_Bulk_UpdateSync_WithHashesNumeric()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
             var onepiece = new List<HashPerson>() {
@@ -175,13 +174,13 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             people[0].Height = 20.2;
             people[0].Age = 25;
             people[1].Age = 52;
-            collection.Update(people);
+           await collection.UpdateAsync(people);
             Assert.NotEqual(onepiece[0].Age, people[0].Age);
         }
 
 
         [Fact]
-        public void TestBulk_UpdateWithEmbbedObject()
+        public async Task Test_BulkUpdate_WithEmbbedObject()
         {
             var collection = new RedisCollection<Person>(_connection);
             var onepiece = new List<Person>() {
@@ -194,12 +193,12 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var people = collection.Where(x => x.NickNames.Contains("Luffy") || x.NickNames.Contains("Shanks")).ToList();
             people[0].Address = new Address { City = "Goa Kingdom" };
             people[1].Address = new Address { City = "Goa Kingdom" };
-            collection.Update(people);
+             await collection.UpdateAsync(people);
             Assert.Contains(people, x => x.Name == onepiece.First().Name);
         }
 
         [Fact]
-        public async Task TestBulk50_RecordsInsertUpdateAndDelAsync()
+        public async Task Test_Bulk50_Records_Insert_Update_Del_Async()
         {
             var collection = new RedisCollection<Person>(_connection, false, 100); // consider using SaveState = false to avoid Concurrent issue
 
@@ -219,7 +218,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 }
                 );
             }
-            var keys = await collection.InsertAsync(people); // 1000 records in an avg of 200ms.
+            var keys = await collection.Insert(people); // 1000 records in an avg of 200ms.
             var listofPeople = (await collection.FindByIdsAsync(keys)).Values.ToList();
             for (int i = 0; i < keys.Count; i++)
             {
@@ -239,7 +238,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestBulk_InsertUpdateDelSyncWithHashes()
+        public async Task TestBulk_Insert_Update_Del_Async_WithHashes()
         {
             var collection = new RedisCollection<HashPerson>(_connection);
             var PhineasFerbShow = new List<HashPerson>() {
@@ -249,7 +248,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 new HashPerson() { Name = "Perry", Age = 5, IsEngineer = false, TagField = "Agent", Address = new Address { State = "Tri-State Area "} }
             };
 
-            await collection.InsertAsync(PhineasFerbShow);
+            await collection.Insert(PhineasFerbShow);
             var searchByName = await collection.Where(x => x.Name == "Dr.Doofenshmirtz" || x.Name == "Perry").ToListAsync(); 
             searchByName[0].TagField = "Vacation";
             searchByName[1].DepartmentNumber = 2;

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -911,63 +911,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public async Task TestBulkInsert()
-        {
-            var collection = new RedisCollection<Person>(_connection);
-            var persons = new List<Person>() {
-                new Person() { Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" }, },
-                new Person() { Name = "Robert", Age = 37, NickNames = new[] { "Bobby", "Rob", "Bob" }, },
-                new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
-                new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
-                };
-            var keys = await collection.Insert(persons);
-            var people = collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToList();
-            Assert.Contains(people, x => x.Name == persons.First().Name);
-        }
-
-        [Fact]
-        public async Task TestBulkInsertWithSameIds()
-        {
-            var collection = new RedisCollection<Person>(_connection);
-            var persons = new List<Person>() {
-                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Alice", Age = 51, NickNames = new[] { "Ally", "Alie", "Al" }, },
-                new Person() {Id="01GFZ9Y6CTEDHHXKT055N1YP3A" , Name = "Robert", Age = 37, NickNames = new[] { "Bobby", "Rob", "Bob" }, },
-                new Person() { Name = "Jeeva", Age = 22, NickNames = new[] { "Jee", "Jeev", "J" }, },
-                new Person() { Name = "Martin", Age = 60, NickNames = new[] { "Mart", "Mat", "tin" }, }
-                };
-            await collection.Insert(persons);
-            var people = await collection.Where(x => x.NickNames.Contains("Bob") || x.NickNames.Contains("Alie")).ToListAsync();
-            Assert.Equal(people.Count, persons.Count - 3);
-            Assert.False(people.First().Name == persons.First().Name); // this fails because the Name field of people doesn't contains the Name value Alice
-        }
-
-        [Fact]
-        public async Task BulkInsert50Records()
-        {
-            var collection = new RedisCollection<Person>(_connection);
-
-            var names = new[] { "Stever", "Martin", "Aegorn", "Robert", "Mary", "Joe", "Mark", "Otto" };
-            var rand = new Random();
-            var people = new List<Person>();
-            for (var i = 0; i < 50; i++)
-            {
-                people.Add(new Person
-                {
-                    Name = names[rand.Next(0, names.Length)],
-                    DepartmentNumber = rand.Next(1, 4),
-                    Sales = rand.Next(50000, 1000000),
-                    Age = rand.Next(17, 21),
-                    Height = 58.0 + rand.NextDouble() * 15,
-                    SalesAdjustment = rand.NextDouble()
-                }
-                );
-            }
-            await collection.Insert(people);
-            var countPeople = collection.Where(x => x.Age >= 17 && x.Age <= 21).ToList().Count;
-            Assert.Equal(people.Count, countPeople);
-        }
-
-        [Fact]
         public async Task TestListContains()
         {
             var collection = new RedisCollection<Person>(_connection);


### PR DESCRIPTION
**Adding feature to Redis-om-dotnet where developers can perform Bulk Operations like Insert, Delete, and Update.**
- [x] Bulk Insert - Insertion of records supports Hash and JSON docs(performance improvement `1000` records in an avg of `200ms`) Closes https://github.com/Jeevananthan-23/redis-om-dotnet/issues/1#issue-1496163279

- [x] Bulk Delete - Unlinks the keys from the Redis.  Closes https://github.com/Jeevananthan-23/redis-om-dotnet/issues/3#issue-1496176859

- [x]  Bulk Update - Update the records.  Closes https://github.com/Jeevananthan-23/redis-om-dotnet/issues/2#issue-1496170149

- [ ] Closes #274, Closes #261, Closes https://github.com/Jeevananthan-23/redis-om-dotnet/issues/4#issue-1496189258 🎉 