### PR TITLE
Feature/configurable timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@Jeevananthan](https://github.com/Jeevananthan-23)
 * [@mariusmuntean](https://github.com/mariusmuntean)
 * [@jcreus1](https://github.com/jcreus1)
+* [@JuliusMikkela](https://github.com/JuliusMikkela)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM.POC/RedisCommands.cs
+++ b/src/Redis.OM.POC/RedisCommands.cs
@@ -3,23 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Text.Json.Serialization;
 using Redis.OM.Contracts;
-using Redis.OM;
-using Redis.OM.Modeling;
 
 namespace Redis.OM
 {
     public static class RedisCommands
     {
-        private static JsonSerializerOptions _options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-        static RedisCommands()
-        {
-            _options.Converters.Add(new GeoLocJsonConverter());
-        }
         public static string Ping(this IRedisConnection connection) => connection.Execute("PING");
 
         public static string Set(this IRedisConnection connection, string key, string value) => connection.Execute("SET", key, value);

--- a/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
+++ b/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Redis.OM.Modeling
             long val = reader.TokenType == JsonTokenType.String ? long.Parse(reader.GetString() !) : reader.GetInt64();
 
             DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return TimeZoneInfo.ConvertTimeFromUtc(dateTime.AddMilliseconds(val), TimeZoneInfo.Local);
+            return TimeZoneInfo.ConvertTimeFromUtc(dateTime.AddMilliseconds(val), RedisSerializationSettings.TimeZone);
         }
 
         /// <inheritdoc />

--- a/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
+++ b/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
@@ -1,11 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Redis.OM;
-using Redis.OM.Modeling;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Redis.OM.Modeling
@@ -15,17 +11,6 @@ namespace Redis.OM.Modeling
     /// </summary>
     public class RedisCollectionStateManager
     {
-        private static readonly JsonSerializerOptions JsonSerializerOptions = new ()
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-
-        static RedisCollectionStateManager()
-        {
-            JsonSerializerOptions.Converters.Add(new GeoLocJsonConverter());
-            JsonSerializerOptions.Converters.Add(new DateTimeJsonConverter());
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="RedisCollectionStateManager"/> class.
         /// </summary>
@@ -118,7 +103,7 @@ namespace Redis.OM.Modeling
 
             if (DocumentAttribute.StorageType == StorageType.Json)
             {
-                var dataJson = JsonSerializer.Serialize(value, JsonSerializerOptions);
+                var dataJson = JsonSerializer.Serialize(value, RedisSerializationSettings.JsonSerializerOptions);
                 var current = JsonConvert.DeserializeObject<JObject>(dataJson, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 var snapshot = (JToken)Snapshot[key];
                 var diff = FindDiff(current!, snapshot);
@@ -153,7 +138,7 @@ namespace Redis.OM.Modeling
                 {
                     if (Data.ContainsKey(key))
                     {
-                        var dataJson = JsonSerializer.Serialize(Data[key], JsonSerializerOptions);
+                        var dataJson = JsonSerializer.Serialize(Data[key], RedisSerializationSettings.JsonSerializerOptions);
                         var current = JsonConvert.DeserializeObject<JObject>(dataJson, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                         var snapshot = (JToken)Snapshot[key];
                         var diff = FindDiff(current!, snapshot);

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Redis.OM.Contracts;
 using Redis.OM.Modeling;
@@ -15,17 +14,6 @@ namespace Redis.OM
     /// </summary>
     public static class RedisCommands
     {
-        private static readonly JsonSerializerOptions Options = new ()
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-
-        static RedisCommands()
-        {
-            Options.Converters.Add(new GeoLocJsonConverter());
-            Options.Converters.Add(new DateTimeJsonConverter());
-        }
-
         /// <summary>
         /// Serializes an object to either hash or json (depending on how it's decorated), and saves it in redis.
         /// </summary>
@@ -150,7 +138,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static async Task<bool> JsonSetAsync(this IRedisConnection connection, string key, string path, object obj)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             var result = await connection.ExecuteAsync("JSON.SET", key, path, json);
             return result == "OK";
         }
@@ -181,7 +169,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static async Task<bool> JsonSetAsync(this IRedisConnection connection, string key, string path, object obj, TimeSpan timeSpan)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             var result = await connection.JsonSetAsync(key, path, json, timeSpan);
             return result;
         }
@@ -224,7 +212,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static async Task<bool> JsonSetAsync(this IRedisConnection connection, string key, string path, object obj, WhenKey when, TimeSpan? timeSpan = null)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             return await connection.JsonSetAsync(key, path, json, when, timeSpan);
         }
 
@@ -292,7 +280,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static bool JsonSet(this IRedisConnection connection, string key, string path, object obj)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             var result = connection.Execute("JSON.SET", key, path, json);
             return result == "OK";
         }
@@ -323,7 +311,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static bool JsonSet(this IRedisConnection connection, string key, string path, object obj, TimeSpan timeSpan)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             return connection.JsonSet(key, path, json, timeSpan);
         }
 
@@ -365,7 +353,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static bool JsonSet(this IRedisConnection connection, string key, string path, object obj, WhenKey when, TimeSpan? timeSpan = null)
         {
-            var json = JsonSerializer.Serialize(obj, Options);
+            var json = JsonSerializer.Serialize(obj, RedisSerializationSettings.JsonSerializerOptions);
             return connection.JsonSet(key, path, json, when, timeSpan);
         }
 
@@ -585,7 +573,7 @@ namespace Redis.OM
             var args = new List<string> { key };
             args.AddRange(paths);
             var res = (string)connection.Execute("JSON.GET", args.ToArray());
-            return !string.IsNullOrEmpty(res) ? JsonSerializer.Deserialize<T>(res, Options) : default;
+            return !string.IsNullOrEmpty(res) ? JsonSerializer.Deserialize<T>(res, RedisSerializationSettings.JsonSerializerOptions) : default;
         }
 
         /// <summary>
@@ -601,7 +589,7 @@ namespace Redis.OM
             var args = new List<string> { key };
             args.AddRange(paths);
             var res = (string)await connection.ExecuteAsync("JSON.GET", args.ToArray());
-            return !string.IsNullOrEmpty(res) ? JsonSerializer.Deserialize<T>(res, Options) : default;
+            return !string.IsNullOrEmpty(res) ? JsonSerializer.Deserialize<T>(res, RedisSerializationSettings.JsonSerializerOptions) : default;
         }
 
         /// <summary>
@@ -791,7 +779,7 @@ namespace Redis.OM
             _ = value ?? throw new ArgumentNullException(nameof(value));
             if (storageType == StorageType.Json)
             {
-                connection.CreateAndEval(nameof(Scripts.UnlinkAndSendJson), new[] { key }, new[] { JsonSerializer.Serialize(value, Options) });
+                connection.CreateAndEval(nameof(Scripts.UnlinkAndSendJson), new[] { key }, new[] { JsonSerializer.Serialize(value, RedisSerializationSettings.JsonSerializerOptions) });
             }
             else
             {
@@ -822,7 +810,7 @@ namespace Redis.OM
             _ = value ?? throw new ArgumentNullException(nameof(value));
             if (storageType == StorageType.Json)
             {
-                await connection.CreateAndEvalAsync(nameof(Scripts.UnlinkAndSendJson), new[] { key }, new[] { JsonSerializer.Serialize(value, Options) });
+                await connection.CreateAndEvalAsync(nameof(Scripts.UnlinkAndSendJson), new[] { key }, new[] { JsonSerializer.Serialize(value, RedisSerializationSettings.JsonSerializerOptions) });
             }
             else
             {

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -17,8 +17,6 @@ namespace Redis.OM
     /// </summary>
     internal static class RedisObjectHandler
     {
-        private static readonly JsonSerializerOptions JsonSerializerOptions = new ();
-
         private static readonly Dictionary<Type, object?> TypeDefaultCache = new ()
         {
             { typeof(string), null },
@@ -29,12 +27,6 @@ namespace Redis.OM
             { typeof(uint), default(uint) },
             { typeof(ulong), default(ulong) },
         };
-
-        static RedisObjectHandler()
-        {
-            JsonSerializerOptions.Converters.Add(new GeoLocJsonConverter());
-            JsonSerializerOptions.Converters.Add(new DateTimeJsonConverter());
-        }
 
         /// <summary>
         /// Builds object from provided hash set.
@@ -64,7 +56,7 @@ namespace Redis.OM
                 asJson = SendToJson(hash, typeof(T));
             }
 
-            return JsonSerializer.Deserialize<T>(asJson, JsonSerializerOptions) ?? throw new Exception("Deserialization fail");
+            return JsonSerializer.Deserialize<T>(asJson, RedisSerializationSettings.JsonSerializerOptions) ?? throw new Exception("Deserialization fail");
         }
 
         /// <summary>
@@ -99,7 +91,7 @@ namespace Redis.OM
                 throw new ArgumentException("Type must be decorated with a DocumentAttribute");
             }
 
-            return JsonSerializer.Deserialize<T>(asJson, JsonSerializerOptions) ?? throw new Exception("Deserialization fail");
+            return JsonSerializer.Deserialize<T>(asJson, RedisSerializationSettings.JsonSerializerOptions) ?? throw new Exception("Deserialization fail");
         }
 
         /// <summary>

--- a/src/Redis.OM/RedisSerializationSettings.cs
+++ b/src/Redis.OM/RedisSerializationSettings.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Redis.OM.Modeling;
+
+namespace Redis.OM
+{
+    /// <summary>
+    /// Configurable settings for how redis handles serialization.
+    /// </summary>
+    public static class RedisSerializationSettings
+    {
+        /// <summary>
+        /// <see cref="JsonSerializerOptions"/> used by redis.
+        /// </summary>
+        public static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        static RedisSerializationSettings()
+        {
+            JsonSerializerOptions.Converters.Add(new GeoLocJsonConverter());
+            JsonSerializerOptions.Converters.Add(new DateTimeJsonConverter());
+        }
+
+        /// <summary>
+        /// Gets default/assumed timezone used by redis when deserializing datetimes.
+        /// </summary>
+        public static TimeZoneInfo TimeZone { get; private set; } = TimeZoneInfo.Local;
+
+        /// <summary>
+        /// Set the default/assumed <see cref="TimeZoneInfo"/> for deserialization to <see cref="TimeZoneInfo.Utc"/> instead of <see cref="TimeZoneInfo.Local"/>.
+        /// </summary>
+        public static void UseUtcTime()
+        {
+            TimeZone = TimeZoneInfo.Utc;
+        }
+
+        /// <summary>
+        /// Set the default/assumed <see cref="TimeZoneInfo"/> for deserialization to the default of <see cref="TimeZoneInfo.Local"/>.
+        /// </summary>
+        public static void UseLocalTime()
+        {
+            TimeZone = TimeZoneInfo.Local;
+        }
+    }
+}

--- a/src/Redis.OM/RedisSerializationSettings.cs
+++ b/src/Redis.OM/RedisSerializationSettings.cs
@@ -6,12 +6,12 @@ using Redis.OM.Modeling;
 namespace Redis.OM
 {
     /// <summary>
-    /// Configurable settings for how redis handles serialization.
+    /// Configurable settings for how serialization and deserialization is handled.
     /// </summary>
     public static class RedisSerializationSettings
     {
         /// <summary>
-        /// <see cref="JsonSerializerOptions"/> used by redis.
+        /// <see cref="JsonSerializerOptions"/> used when serializing.
         /// </summary>
         public static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions()
         {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -151,9 +151,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         public void TestSave()
         {
             var collection = new RedisCollection<Person>(_connection,10000);
-            var count = collection.Count();
+            var count = 0;
             foreach (var person in collection)
             {
+                count++;
                 person.Name = "TestSave";
                 person.Mother = new Person {Name = "Diane"};
             }
@@ -204,9 +205,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         public async Task TestSaveHashAsync()
         {
             var collection = new RedisCollection<HashPerson>(_connection, 10000);
-            var count = collection.Count();
+            var count = 0;
             await foreach (var person in collection)
             {
+                count++;
                 person.Name = "TestSaveHashAsync";
                 person.Mother = new HashPerson {Name = "Diane"};
             }

--- a/test/Redis.OM.Unit.Tests/Serialization/DateTimeSerializationTest.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/DateTimeSerializationTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Redis.OM.Contracts;
 using Xunit;
 
@@ -19,6 +17,7 @@ namespace Redis.OM.Unit.Tests
         [Fact]
         public void TestDateTimeSerialization()
         {
+            RedisSerializationSettings.UseLocalTime();
             var time = DateTime.Now;
             var obj = new ObjectWithATimestamp { Name = "Foo", Time = time };
             var objNonNullNullTime = new ObjectWithATimestamp { Name = "bar", Time = time, NullableTime = time };
@@ -34,7 +33,24 @@ namespace Redis.OM.Unit.Tests
         [Fact]
         public void TestJsonDateTimeSerialization()
         {
+            RedisSerializationSettings.UseLocalTime();
             var time = DateTime.Now;
+            var obj = new JsonObjectWithDateTime { Name = "Foo", Time = time };
+            var objNonNullNullTime = new JsonObjectWithDateTime { Name = "bar", Time = time, NullableTime = time };
+            var id = _connection.Set(obj);
+            var id2 = _connection.Set(objNonNullNullTime);
+            var reconstituted = _connection.Get<JsonObjectWithDateTime>(id);
+            var reconstitutedObj2 = _connection.Get<JsonObjectWithDateTime>(id2);
+            Assert.Equal(time.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"), reconstituted.Time.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"));
+            Assert.Null(reconstituted.NullableTime);
+            Assert.Equal(time.ToString("yyyy-MM-ddTHH:mm:ss.fff"), reconstitutedObj2.NullableTime.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff"));
+        }
+
+        [Fact]
+        public void TestJsonUtcDateTimeSerialization()
+        {
+            RedisSerializationSettings.UseUtcTime();
+            var time = DateTime.UtcNow;
             var obj = new JsonObjectWithDateTime { Name = "Foo", Time = time };
             var objNonNullNullTime = new JsonObjectWithDateTime { Name = "bar", Time = time, NullableTime = time };
             var id = _connection.Set(obj);


### PR DESCRIPTION
Added the option to change TimeZone used by DateTimeJsonConverter to allow deserialization into UTC-DateTimes instead of Local ones, which can be a hassle to reverse-engineer in environments where Local is unreliable or undesirable.

Should resolve or at least mitigate #271 and shouldn't cause any breaking changes since the UTC setting is opt-in.

Also centralized a lof of duplicated JsonSerializerSettings, and technically allows users to tinker with the settings themselves (at their own risk, naturally).