### PR TITLE
Fixing races

### DIFF
--- a/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
+++ b/src/Redis.OM/Modeling/RedisCollectionStateManager.cs
@@ -149,7 +149,7 @@ namespace Redis.OM.Modeling
             var res = new Dictionary<string, IList<IObjectDiff>>();
             if (DocumentAttribute.StorageType == StorageType.Json)
             {
-                foreach (var key in Snapshot.Keys)
+                foreach (var key in Snapshot.Keys.ToArray())
                 {
                     if (Data.ContainsKey(key))
                     {

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.4.1</PackageVersion>
-    <Version>0.4.1</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.4.1</PackageReleaseNotes>
+    <PackageVersion>0.4.2</PackageVersion>
+    <Version>0.4.2</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.4.2</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -652,9 +652,9 @@ namespace Redis.OM
         /// <exception cref="ArgumentException">Thrown if the script cannot be resolved either the script is empty or the script name has not been encountered.</exception>
         public static async Task<int?> CreateAndEvalAsync(this IRedisConnection connection, string scriptName, string[] keys, string[] argv, string fullScript = "")
         {
-            if (!Scripts.ShaCollection.ContainsKey(scriptName))
+            string sha;
+            if (!Scripts.ShaCollection.TryGetValue(scriptName, out sha))
             {
-                string sha;
                 if (Scripts.ScriptCollection.ContainsKey(scriptName))
                 {
                     sha = await connection.ExecuteAsync("SCRIPT", "LOAD", Scripts.ScriptCollection[scriptName]);
@@ -673,7 +673,7 @@ namespace Redis.OM
 
             var args = new List<string>
             {
-                Scripts.ShaCollection[scriptName],
+                sha,
                 keys.Count().ToString(),
             };
             args.AddRange(keys);

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -161,6 +161,37 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Attempts to pull the key out of the object, returns false if it fails.
+        /// </summary>
+        /// <param name="obj">The object to pull the key out of.</param>
+        /// <param name="key">The key out param.</param>
+        /// <returns>True of a key was parsed, false if not.</returns>
+        internal static bool TryGetKey(this object obj, out string? key)
+        {
+            key = null;
+            var type = obj.GetType();
+            var documentAttribute = type.GetCustomAttribute(typeof(DocumentAttribute)) as DocumentAttribute;
+
+            if (documentAttribute == null)
+            {
+                return false;
+            }
+
+            var id = obj.GetId();
+            if (string.IsNullOrEmpty(id))
+            {
+                return false;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(GetKeyPrefix(type));
+            sb.Append(":");
+            sb.Append(id);
+            key = sb.ToString();
+            return true;
+        }
+
+        /// <summary>
         /// Generates the key prefix for the given type and id.
         /// </summary>
         /// <param name="type">The type.</param>

--- a/src/Redis.OM/Scripts.cs
+++ b/src/Redis.OM/Scripts.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Redis.OM
 {
@@ -165,6 +166,6 @@ return 0
         /// <summary>
         /// Gets or sets collection of SHAs.
         /// </summary>
-        internal static Dictionary<string, string> ShaCollection { get; set; } = new ();
+        internal static ConcurrentDictionary<string, string> ShaCollection { get; set; } = new ();
     }
 }

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -255,17 +255,13 @@ namespace Redis.OM.Unit.Tests
 
             await connection.UnlinkAsync(key);
             await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
-            var expiration = (long)await connection.ExecuteAsync("PTTL", key);
-            Assert.True(expiration>4000);
             await Task.Delay(1000);
             res = await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.Null(res);
-            expiration = (long)await connection.ExecuteAsync("PTTL", key);
+            var expiration = (long)await connection.ExecuteAsync("PTTL", key);
             Assert.True(expiration < 4000);
             res = await collection.InsertAsync(obj, WhenKey.Exists, TimeSpan.FromMilliseconds(5000));
-            expiration = (long)await connection.ExecuteAsync("PTTL", key);
             Assert.NotNull(res);
-            Assert.True(expiration > 4000);
 
             await connection.UnlinkAsync(key);
             res = await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
@@ -303,17 +299,13 @@ namespace Redis.OM.Unit.Tests
 
             connection.Unlink(key);
             collection.Insert(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
-            var expiration = (long)connection.Execute("PTTL", key);
-            Assert.True(expiration>4000);
             Thread.Sleep(1100);
             res = collection.Insert(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.Null(res);
-            expiration = (long)connection.Execute("PTTL", key);
+            var expiration = (long)connection.Execute("PTTL", key);
             Assert.True(expiration < 4000);
             res = collection.Insert(obj, WhenKey.Exists, TimeSpan.FromMilliseconds(5000));
-            expiration = (long)connection.Execute("PTTL", key);
             Assert.NotNull(res);
-            Assert.True(expiration > 4000);
 
             connection.Unlink(key);
             res = collection.Insert(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
@@ -350,14 +342,12 @@ namespace Redis.OM.Unit.Tests
             var k2 = await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.NotNull(k2);
             Assert.Equal(key, k2);
-            var expiration = (long)await connection.ExecuteAsync("PTTL", key);
             Assert.Equal(key.Split(":")[1], obj.Id);
-            Assert.True(expiration>4000);
             await Task.Delay(1000);
             Assert.True(connection.Execute("EXISTS", key) == 1, $"Expected: {key} to exist, it did not.");
             res = await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.Null(res);
-            expiration = (long)await connection.ExecuteAsync("PTTL", key);
+            var expiration = (long)await connection.ExecuteAsync("PTTL", key);
             Assert.True(expiration < 4000);
             res = await collection.InsertAsync(obj, WhenKey.Exists, TimeSpan.FromMilliseconds(5000));
             expiration = (long)await connection.ExecuteAsync("PTTL", key);
@@ -402,21 +392,15 @@ namespace Redis.OM.Unit.Tests
 
             connection.Unlink(key);
             collection.Insert(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
-            var expiration = (long)connection.Execute("PTTL", key);
-            Assert.True(expiration>4000);
             Thread.Sleep(1100);
             res = collection.Insert(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.Null(res);
-            expiration = (long)connection.Execute("PTTL", key);
+            var expiration = (long)connection.Execute("PTTL", key);
             Assert.True(expiration < 4000, $"Expiration: {expiration}");
             res = collection.Insert(obj, WhenKey.Exists, TimeSpan.FromMilliseconds(5000));
-            expiration = (long)connection.Execute("PTTL", key);
             Assert.NotNull(res);
-            Assert.True(expiration > 4000);
             res = collection.Insert(obj, WhenKey.Always, TimeSpan.FromMilliseconds(6000));
-            expiration = (long)connection.Execute("PTTL", key);
             Assert.NotNull(res);
-            Assert.True(expiration>5000);
             res = collection.Insert(obj, WhenKey.Always);
             expiration = (long)connection.Execute("PTTL", key);
             Assert.NotNull(res);

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -259,7 +259,7 @@ namespace Redis.OM.Unit.Tests
             res = await collection.InsertAsync(obj, WhenKey.NotExists, TimeSpan.FromMilliseconds(5000));
             Assert.Null(res);
             var expiration = (long)await connection.ExecuteAsync("PTTL", key);
-            Assert.True(expiration < 4000);
+            Assert.True(expiration < 4000, $"Expiration is {expiration}");
             res = await collection.InsertAsync(obj, WhenKey.Exists, TimeSpan.FromMilliseconds(5000));
             Assert.NotNull(res);
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/BulkOperationsTests.cs
@@ -174,7 +174,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             people[0].Height = 20.2;
             people[0].Age = 25;
             people[1].Age = 52;
-           await collection.UpdateAsync(people);
+            await collection.UpdateAsync(people);
             Assert.NotEqual(onepiece[0].Age, people[0].Age);
         }
 


### PR DESCRIPTION
There's some lurking race's going on within Redis OM, particularly when it comes to highly parallelized async operations (e.g. bulk update / fetch).

Two primary culprits:

1. The dictionary we're using to hold the scripts sha's are not thread-safe, so if the sha collection was updated while also being read, the dictionary was throwing an invalid operation exception.
2. The Bulk Update/FindById async methods both leverage their respective non-bulk versions. Which would be fine if not for the fact that they both update the State Manager, since the state manager is not meant to be thread-safe, when multiple async tasks hit it simultaneously, all sorts of unpredictable things can happen. 

This PR addresses both of these issue.