### PR TITLE
fixing paths to nested objects in various predicates

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -375,7 +375,7 @@ namespace Redis.OM.Common
 
             if (exp is MemberExpression member)
             {
-                return $"{member.Member.Name}";
+                return ExpressionParserUtilities.GetSearchFieldNameFromMember(member);
             }
 
             if (exp is MethodCallExpression method)
@@ -411,7 +411,7 @@ namespace Redis.OM.Common
 
             if (exp is MemberExpression member)
             {
-                return new[] { $"{member.Member.Name}" };
+                return new[] { ExpressionParserUtilities.GetSearchFieldNameFromMember(member) };
             }
 
             if (exp is MethodCallExpression method)
@@ -431,7 +431,7 @@ namespace Redis.OM.Common
 
             if (exp is NewExpression newExpression)
             {
-                return newExpression.Members != null ? newExpression.Members.Select(x => $"{x.Name}").ToArray() : Array.Empty<string>();
+                return newExpression.Members != null ? newExpression.Arguments.Select(GetFieldName).ToArray() : Array.Empty<string>();
             }
 
             throw new ArgumentException("Invalid expression type detected");
@@ -582,7 +582,7 @@ namespace Redis.OM.Common
             var predicate = (UnaryExpression)expression.Arguments[1];
             var lambda = (LambdaExpression)predicate.Operand;
             var memberExpression = (MemberExpression)lambda.Body;
-            sb.Field = memberExpression.Member.Name;
+            sb.Field = ExpressionParserUtilities.GetSearchFieldNameFromMember(memberExpression);
             sb.Direction = ascending ? SortDirection.Ascending : SortDirection.Descending;
             return sb;
         }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -386,5 +386,45 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _ = collection.OrderBy(x => x.RecordShell.Name).OrderByDescending(x => x.RecordShell.Age).ToList();
             _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "SORTBY", "4", "@Name", "ASC", "@Age", "DESC", "WITHCURSOR", "COUNT", "10000"));
         }
+
+        [Fact]
+        public void TestNestedOrderBy()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.OrderBy(x => x.RecordShell.Address.State).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "SORTBY", "2", "@Address_State", "ASC", "WITHCURSOR", "COUNT", "10000"));
+        }
+
+        [Fact]
+        public void TestNestedGroup()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.GroupBy(x => x.RecordShell.Address.State).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "GROUPBY", "1", "@Address_State", "WITHCURSOR", "COUNT", "10000"));
+        }
+
+        [Fact]
+        public void TestNestedGroupMulti()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.GroupBy(x => new {x.RecordShell.Address.State, x.RecordShell.Address.ForwardingAddress.City}).ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "GROUPBY", "2", "@Address_State", "@Address_ForwardingAddress_City", "WITHCURSOR", "COUNT", "10000"));
+        }
+
+        [Fact]
+        public void TestNestedApply()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.Apply(x => x.RecordShell.Address.HouseNumber + 4, "house_num_modified").ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "APPLY", "@Address_HouseNumber + 4", "AS", "house_num_modified", "WITHCURSOR", "COUNT", "10000"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #289 and #291 which are both caused by separate instances of us not tearing down the path to nested objects correctly in their respective predicates