### PR TITLE
adding back context for lost where clauses

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -233,6 +233,9 @@ namespace Redis.OM.Common
                             case "GeoFilter":
                                 query.GeoFilter = ExpressionParserUtilities.TranslateGeoFilter(exp);
                                 break;
+                            case "Where":
+                                query.QueryText = TranslateWhereMethod(exp);
+                                break;
                         }
                     }
 
@@ -244,8 +247,10 @@ namespace Redis.OM.Common
                     break;
             }
 
-            query.QueryText = mainBooleanExpression == null ? "*" : BuildQueryFromExpression(
-                ((LambdaExpression)mainBooleanExpression).Body);
+            if (mainBooleanExpression != null)
+            {
+                query.QueryText = BuildQueryFromExpression(((LambdaExpression)mainBooleanExpression).Body);
+            }
 
             return query;
         }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2867,7 +2867,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "100",
                 "RETURN",
                 "1",
-                "Name"
+                "Name"));
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2850,5 +2850,26 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "km"
             ));
         }
+        
+        [Fact]
+        public void TestSelectWithWhere()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_mock.Object);
+            _ = collection.Where(x => x.Age == 33).Select(x => x.Name).ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Age:[33 33])",
+                "LIMIT",
+                "0",
+                "100",
+                "RETURN",
+                "1",
+                "Name"
+            ));
+        }
     }
 }


### PR DESCRIPTION
Fixes #307 - When implementing #157 - removed the `Where` parsing because the boolean expression was being fully parsed below, if someone uses a `SELECT` however, all that context is lost - bringing it back.