### PR TITLE
fixing nullable enum parsing

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -259,12 +259,13 @@ namespace Redis.OM.Common
         {
             if (member is PropertyInfo info)
             {
-                if (TypeDeterminationUtilities.IsNumeric(info.PropertyType))
+                var type = Nullable.GetUnderlyingType(info.PropertyType) ?? info.PropertyType;
+                if (TypeDeterminationUtilities.IsNumeric(type))
                 {
                     return SearchFieldType.NUMERIC;
                 }
 
-                if (info.PropertyType.IsEnum)
+                if (type.IsEnum)
                 {
                     return TypeDeterminationUtilities.GetSearchFieldFromEnumProperty(info);
                 }
@@ -334,7 +335,8 @@ namespace Redis.OM.Common
                     {
                         if (!int.TryParse(rightContent, out _) && !long.TryParse(rightContent, out _))
                         {
-                            rightContent = ((int)Enum.Parse(member.Type, rightContent)).ToString();
+                            var type = Nullable.GetUnderlyingType(member.Type) ?? member.Type;
+                            rightContent = ((int)Enum.Parse(type, rightContent)).ToString();
                         }
                     }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithStringLikeValueTypes.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithStringLikeValueTypes.cs
@@ -43,4 +43,13 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         [Indexed]
         public AnEnum AnEnum { get; set; }
     }
+
+    [Document]
+    public class ObjectWithNullableEnum
+    {
+        [Indexed] public AnEnum? AnEnum { get; set; }
+        [Indexed]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public AnEnum? NullableStringEnum { get; set; }
+    }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2850,5 +2850,23 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "km"
             ));
         }
+
+        [Fact]
+        public void TestNullableEnumQueries()
+        {
+            _mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(_mockReply);
+
+            var collection = new RedisCollection<ObjectWithNullableEnum>(_mock.Object);
+            collection.Where(x => x.AnEnum == AnEnum.one && x.NullableStringEnum == AnEnum.two).ToList();
+            _mock.Verify(x => x.Execute(
+                "FT.SEARCH",
+                "objectwithnullableenum-idx",
+                "((@AnEnum:[0 0]) (@NullableStringEnum:{two}))",
+                "LIMIT",
+                "0",
+                "100"
+            ));
+        }
     }
 }


### PR DESCRIPTION
Fixes #309 - Not properly finding underpinning types of Nullable Enums - extracting type when building queries.