### PR TITLE
fixing bin expression detection

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -108,6 +108,26 @@ namespace Redis.OM.Common
         }
 
         /// <summary>
+        /// Determines whether it's a binary expression.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <returns>Whether or not it's a binary expression.</returns>
+        internal static bool IsBinaryExpression(Expression expression)
+        {
+            if (expression is BinaryExpression)
+            {
+                return true;
+            }
+
+            if (expression is UnaryExpression uni && uni.Operand is BinaryExpression)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Splits the expression apart into a query.
         /// </summary>
         /// <param name="rootBinaryExpression">The root expression.</param>
@@ -130,7 +150,7 @@ namespace Redis.OM.Common
 
                 operationStack.Push(right);
                 operationStack.Push(GetOperatorFromNodeType(expression.NodeType));
-                if (!string.IsNullOrEmpty(left) && !(expression.Left is BinaryExpression))
+                if (!string.IsNullOrEmpty(left) && !IsBinaryExpression(expression.Left))
                 {
                     operationStack.Push(left);
                 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -426,5 +426,16 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _ = collection.Apply(x => x.RecordShell.Address.HouseNumber + 4, "house_num_modified").ToList();
             _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "APPLY", "@Address_HouseNumber + 4", "AS", "house_num_modified", "WITHCURSOR", "COUNT", "10000"));
         }
+
+        [Fact]
+        public void TestMissedBinExpression()
+        {
+            var collection = new RedisAggregationSet<Person>(_mock.Object, true, chunkSize: 10000);
+            _mock.Setup(x => x.Execute("FT.AGGREGATE", It.IsAny<string[]>())).Returns(MockedResult);
+            _mock.Setup(x => x.Execute("FT.CURSOR", It.IsAny<string[]>())).Returns(MockedResultCursorEnd);
+            _ = collection.Apply(x => x.RecordShell.Address.HouseNumber + 4, "house_num_modified")
+                .Apply(x=>x.RecordShell.Age + x["house_num_modified"] * 4 + x.RecordShell.Sales, "arbitrary_calculation").ToList();
+            _mock.Verify(x=>x.Execute("FT.AGGREGATE","person-idx", "*", "APPLY", "@Address_HouseNumber + 4", "AS", "house_num_modified", "APPLY", "@Age + @house_num_modified * 4 + @Sales", "AS", "arbitrary_calculation", "WITHCURSOR", "COUNT", "10000"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #317 

The fundamental issue is that binary expressions weren't being detected correctly, so when it was joining everything together the expression translator was pushing parsed expressions onto the stack erroneously 