### PR TITLE
fixing selects with same names

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -627,14 +627,7 @@ namespace Redis.OM.Common
                         if (assignment.Expression is MemberExpression assignmentExpression)
                         {
                             var path = AliasOrPath(t, attr, assignmentExpression);
-                            if (assignmentExpression.Member.Name == binding.Member.Name)
-                            {
-                                returnFields.Add(new (path));
-                            }
-                            else
-                            {
-                                returnFields.Add(new (path, binding.Member.Name));
-                            }
+                            returnFields.Add(new (path, binding.Member.Name));
                         }
                     }
                 }

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.5.1</PackageVersion>
-    <Version>0.5.1</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.5.1</PackageReleaseNotes>
+    <PackageVersion>0.5.2</PackageVersion>
+    <Version>0.5.2</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.5.2</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -1096,13 +1096,19 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(42,resAnonWithAssignments.Field3.InnerInnerCascade.Num);
             Assert.Equal("World",resAnonWithAssignments.Field4.InnerInnerCascade.Tag);
             Assert.Equal(42,resAnonWithAssignments.Field4.InnerInnerCascade.Num);
-
+            
             var resWithOtherObject = collection.Select(x => new CongruentObject{Field3 = x.Field1, Field4 = x.Field2}).ToList().First();
             Assert.Equal("World",resWithOtherObject.Field3.InnerInnerCascade.Tag);
             Assert.Equal(42,resWithOtherObject.Field3.InnerInnerCascade.Num);
             Assert.Equal("World",resWithOtherObject.Field4.InnerInnerCascade.Tag);
             Assert.Equal(42,resWithOtherObject.Field4.InnerInnerCascade.Num);
             
+            var resWithOtherObjectLikeNames = collection.Select(x => new CongruentObjectWithLikeNames(){Field1 = x.Field1, Field2 = x.Field2}).ToList().First();
+            Assert.Equal("World",resWithOtherObjectLikeNames.Field1.InnerInnerCascade.Tag);
+            Assert.Equal(42,resWithOtherObjectLikeNames.Field1.InnerInnerCascade.Num);
+            Assert.Equal("World",resWithOtherObjectLikeNames.Field2.InnerInnerCascade.Tag);
+            Assert.Equal(42,resWithOtherObjectLikeNames.Field2.InnerInnerCascade.Num);
+
             var resNoNew = collection.Select(x => x.Field1).ToList().First();
             Assert.Equal("World",resNoNew.InnerInnerCascade.Tag);
             Assert.Equal(42,resNoNew.InnerInnerCascade.Num);

--- a/test/Redis.OM.Unit.Tests/Serialization/SelectTestObject.cs
+++ b/test/Redis.OM.Unit.Tests/Serialization/SelectTestObject.cs
@@ -16,3 +16,9 @@ public class CongruentObject
     public InnerObject Field3 { get; set; }
     public InnerObject Field4 { get; set; }
 }
+
+public class CongruentObjectWithLikeNames
+{
+    public InnerObject Field1 { get; set; }
+    public InnerObject Field2 { get; set; }
+}


### PR DESCRIPTION
Fixes #371 - decision to not alias if field name was the same in the object being projected onto as the initial object was apparently ill-advised as it was making it impossible to parse correctly.