### PR TITLE
Fix indexing and querying GUID lists

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -714,7 +714,7 @@ namespace Redis.OM.Common
                 var treatEnumsAsInts = type.IsEnum && !(propertyExpression.Member.GetCustomAttributes(typeof(JsonConverterAttribute)).FirstOrDefault() is JsonConverterAttribute converter && converter.ConverterType == typeof(JsonStringEnumConverter));
                 literal = GetOperandStringForQueryArgs(valuesExpression, treatEnumsAsInts);
 
-                if ((type == typeof(string) || type == typeof(string[]) || type == typeof(List<string>) || type == typeof(Guid) || type == typeof(Ulid) || (type.IsEnum && !treatEnumsAsInts)) && attribute is IndexedAttribute)
+                if ((type == typeof(string) || type == typeof(string[]) || type == typeof(List<string>) || type == typeof(Guid) || type == typeof(Guid[]) || type == typeof(List<Guid>) || type == typeof(Ulid) || (type.IsEnum && !treatEnumsAsInts)) && attribute is IndexedAttribute)
                 {
                     return $"({memberName}:{{{EscapeTagField(literal).Replace("\\|", "|")}}})";
                 }

--- a/src/Redis.OM/Modeling/RedisSchemaField.cs
+++ b/src/Redis.OM/Modeling/RedisSchemaField.cs
@@ -104,7 +104,7 @@ namespace Redis.OM.Modeling
             return ret.ToArray();
         }
 
-        private static bool IsTypeIndexableArray(Type t) => t == typeof(string[]) || t == typeof(bool[]) || t == typeof(List<string>) || t == typeof(List<bool>);
+        private static bool IsTypeIndexableArray(Type t) => t == typeof(string[]) || t == typeof(bool[]) || t == typeof(Guid[]) || t == typeof(List<string>) || t == typeof(List<bool>) || t == typeof(List<Guid>);
 
         private static IEnumerable<string> SerializeIndexFromJsonPaths(PropertyInfo parentInfo, SearchFieldAttribute attribute, string prefix = "$.", string aliasPrefix = "", int remainingDepth = -1)
         {


### PR DESCRIPTION
There is a problem when using [Indexed] `List<Guid>` right now - index for them is not created, and querying is not working. This will fix this.
However, as I can see right now, current aprroach is quite bad - you have to manually add new types and it's possible to forget to add it in one place or another. 
And I had to spend a few hours to find out, why `List<Guid>` is not working, there was no indication from RedisOM that I'm doing something wrong.

Also, you probably can't cover all types, that can be indexed: user can use for indexing any signle-line field (DateTime, DateTimeOffset, Enum, Uri, and the list goes on, not to mention it's possible to create custom types). All these types can be serialized as valid JSON single-line fields (string or number)
So, you need to check not the base type, but the JSON-serialized type of the object (with JsonConverter attribute, if it's there). This seems to be a complex task, so I'll leave it to you =)