### PR TITLE
Bugfix - Enumerating collection with documents expiring causes early return

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@imansafari1991](https://github.com/imansafari1991)
 * [@AndersenGans](https://github.com/AndersenGans)
 * [@mdrakib](https://github.com/mdrakib)
+* [@jrpavoncello](https://github.com/jrpavoncello)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.5.4</PackageVersion>
-    <Version>0.5.4</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.5.4</PackageReleaseNotes>
+    <PackageVersion>0.5.5</PackageVersion>
+    <Version>0.5.5</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.5.5</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
+++ b/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
@@ -94,7 +94,7 @@ namespace Redis.OM.Searching
             switch (_started)
             {
                 case true when _limited:
-                case true when _records.Documents.Count < _query!.Limit!.Number:
+                case true when _records.Documents.Count < _query!.Limit!.Number && _records.DocumentsSkippedCount == 0:
                     return false;
                 default:
                     return GetNextChunk();
@@ -113,7 +113,7 @@ namespace Redis.OM.Searching
             switch (_started)
             {
                 case true when _limited:
-                case true when _records.Documents.Count < _query!.Limit!.Number:
+                case true when _records.Documents.Count < _query!.Limit!.Number && _records.DocumentsSkippedCount == 0:
                     return false;
                 default:
                     return await GetNextChunkAsync();

--- a/src/Redis.OM/Searching/SearchResponse.cs
+++ b/src/Redis.OM/Searching/SearchResponse.cs
@@ -126,7 +126,7 @@ namespace Redis.OM.Searching
                     }
                     else
                     {
-                        DocumentsSkippedCount++;
+                        DocumentsSkippedCount++; // needed when a key expired while it was being enumerated by Redis.
                     }
                 }
             }

--- a/src/Redis.OM/Searching/SearchResponse.cs
+++ b/src/Redis.OM/Searching/SearchResponse.cs
@@ -124,6 +124,10 @@ namespace Redis.OM.Searching
                         var obj = RedisObjectHandler.FromHashSet<T>(documentHash);
                         Documents.Add(docId, obj);
                     }
+                    else
+                    {
+                        DocumentsSkippedCount++;
+                    }
                 }
             }
         }
@@ -131,6 +135,7 @@ namespace Redis.OM.Searching
         private SearchResponse()
         {
             DocumentCount = 0;
+            DocumentsSkippedCount = 0;
             Documents = new Dictionary<string, T>();
         }
 
@@ -138,6 +143,12 @@ namespace Redis.OM.Searching
         /// Gets or sets the number of documents found by the search.
         /// </summary>
         public long DocumentCount { get; set; }
+
+        /// <summary>
+        /// Gets the number of documents skipped while enumerating the search result set.
+        /// This can be indicative of documents that have expired during enumeration.
+        /// </summary>
+        public int DocumentsSkippedCount { get; private set; }
 
         /// <summary>
         /// Gets the documents.


### PR DESCRIPTION
Addresses bug found in #421 i.e. enumerating a collection from a search where the documents were expiring causes an early return resulting in less documents than expected.

@slorello89 Side note - I noticed that the non-generic [SearchResponse](https://github.com/redis/redis-om-dotnet/blob/fa80a84bb141ab0b6ff44fdf8f2a5e59a8120aee/src/Redis.OM/Searching/SearchResponse.cs#L11) would [return an empty Document](https://github.com/redis/redis-om-dotnet/blob/fa80a84bb141ab0b6ff44fdf8f2a5e59a8120aee/src/Redis.OM/Searching/SearchResponse.cs#L25C1-L32C52) i.e. an empty dictionary documentHash, akin to returning null. But the generic `SearchResponse<T>` just skips the document instead. In the same vein, [AggregationResult](https://github.com/redis/redis-om-dotnet/blob/fa80a84bb141ab0b6ff44fdf8f2a5e59a8120aee/src/Redis.OM/Aggregation/AggregationResult.cs#L86) and [AggregationResult\<T\>](https://github.com/redis/redis-om-dotnet/blob/fa80a84bb141ab0b6ff44fdf8f2a5e59a8120aee/src/Redis.OM/Aggregation/AggregationResult.cs#L15) also seem to have a general pattern of returning `null` to their callers (whether internal or external to this package). This seemed like an unexpected functional difference between these classes that all handle a `RedisReply`s so I wanted to call it to your attention for potential future review since these would be out of scope of a patch.