### PR TITLE
Bugfix/vector hash idx creation

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,5 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v2
+      - name: fetch-models
+        run: sh fetch-models.sh
       - name: execute
         run: docker-compose -f ./docker/docker-compose.yaml run dotnet

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,7 +11,5 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v2
-        with:
-          lfs: true
       - name: execute
         run: docker-compose -f ./docker/docker-compose.yaml run dotnet

--- a/fetch-models.sh
+++ b/fetch-models.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rm src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/model.onnx
+curl -o ./src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/model.onnx https://storage.googleapis.com/slorello/model.onnx
+
+rm src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/vocab.txt
+curl -o ./src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/vocab.txt https://storage.googleapis.com/slorello/vocab.txt
+
+rm src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNet18.onnx 
+curl -o ./src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNet18.onnx  https://storage.googleapis.com/slorello/ResNet18.onnx
+
+rm src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNetPreprocess.onnx 
+curl -o ./src/Redis.OM.Vectorizers.Resnet18/Resources/ResNetPrepOnnx/ResNetPreprocess.onnx  https://storage.googleapis.com/slorello/ResNetPreprocess.onnx

--- a/fetch-models.sh
+++ b/fetch-models.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-rm src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/model.onnx
 curl -o ./src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/model.onnx https://storage.googleapis.com/slorello/model.onnx
 
-rm src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/vocab.txt
 curl -o ./src/Redis.OM.Vectorizers.AllMiniLML6V2/Resources/vocab.txt https://storage.googleapis.com/slorello/vocab.txt
 
-rm src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNet18.onnx 
 curl -o ./src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNet18.onnx  https://storage.googleapis.com/slorello/ResNet18.onnx
 
-rm src/Redis.OM.Vectorizers.Resnet18/Resources/ResNet18Onnx/ResNetPreprocess.onnx 
 curl -o ./src/Redis.OM.Vectorizers.Resnet18/Resources/ResNetPrepOnnx/ResNetPreprocess.onnx  https://storage.googleapis.com/slorello/ResNetPreprocess.onnx

--- a/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
+++ b/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.AllMiniLML6V2</RootNamespace>
-        <PackageVersion>0.6.0</PackageVersion>
-        <Version>0.6.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.0</PackageReleaseNotes>
+        <PackageVersion>0.6.1</PackageVersion>
+        <Version>0.6.1</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
         <Description>Sentence Vectorizer for Redis OM .NET using all-MiniLM-L6-v2</Description>
         <Title>Redis OM all-MiniLM-L6-v2 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
+++ b/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
@@ -4,9 +4,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.Resnet18</RootNamespace>
-        <PackageVersion>0.6.0</PackageVersion>
-        <Version>0.6.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.0</PackageReleaseNotes>
+        <PackageVersion>0.6.1</PackageVersion>
+        <Version>0.6.1</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
         <Description>Resnet 18 Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Resnet 18 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
+++ b/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM</RootNamespace>
-        <PackageVersion>0.6.0</PackageVersion>
-        <Version>0.6.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.0</PackageReleaseNotes>
+        <PackageVersion>0.6.1</PackageVersion>
+        <Version>0.6.1</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
         <Description>Core Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/Modeling/RedisSchemaField.cs
+++ b/src/Redis.OM/Modeling/RedisSchemaField.cs
@@ -119,7 +119,13 @@ namespace Redis.OM.Modeling
                 }
             }
 
-            var ret = new List<string> { !string.IsNullOrEmpty(attr.PropertyName) ? $"attr.PropertyName{suffix}" : $"{info.Name}{suffix}" };
+            var ret = new List<string> { !string.IsNullOrEmpty(attr.PropertyName) ? $"{attr.PropertyName}{suffix}" : $"{info.Name}{suffix}" };
+            if (!string.IsNullOrEmpty(suffix))
+            {
+                ret.Add("AS");
+                ret.Add(!string.IsNullOrEmpty(attr.PropertyName) ? attr.PropertyName : info.Name);
+            }
+
             var innerType = Nullable.GetUnderlyingType(info.PropertyType);
             ret.AddRange(CommonSerialization(attr, innerType ?? info.PropertyType, info));
             return ret.ToArray();

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.6.0</PackageVersion>
-    <Version>0.6.0</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.0</PackageReleaseNotes>
+    <PackageVersion>0.6.1</PackageVersion>
+    <Version>0.6.1</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -639,7 +639,7 @@ namespace Redis.OM
                     }
 
                     var valueStr = $"[{arrString}]";
-                    ret += $"\"Vector\":{valueStr}}}";
+                    ret += $"\"Vector\":{valueStr}}},";
                 }
             }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/HuggingFaceVectors.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/HuggingFaceVectors.cs
@@ -4,7 +4,7 @@ using Redis.OM.Modeling.Vectors;
 
 namespace Redis.OM.Unit.Tests;
 
-[Document(StorageType = StorageType.Json)]
+[Document]
 public class HuggingFaceVectors
 {
     [RedisIdField]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
@@ -237,6 +237,26 @@ public class VectorFunctionalTests
     }
     
     [Fact]
+    public void ScoresOnHashVectorizer()
+    {
+        _connection.DropIndexAndAssociatedRecords(typeof(ObjectWithVectorHash));
+        _connection.CreateIndex(typeof(ObjectWithVectorHash));
+        var simpleHnswVector = Vector.Of(Enumerable.Range(0, 10).Select(x => (double)x).ToArray());
+        var simpleVectorizedVector = Vector.Of("foo");
+        var obj = new ObjectWithVectorHash
+        {
+            Id = "helloWorld",
+            SimpleHnswVector = simpleHnswVector,
+            SimpleVectorizedVector = simpleVectorizedVector,
+        };
+        var collection = new RedisCollection<ObjectWithVectorHash>(_connection);
+        collection.Insert(obj);
+        var res = collection.NearestNeighbors(x => x.SimpleVectorizedVector, 5, "foo").First();
+
+        Assert.Equal(0, res.VectorScores.NearestNeighborsScore);
+    }
+
+    [Fact]
     public void HybridQueryTest()
     {
         _connection.DropIndexAndAssociatedRecords(typeof(ObjectWithVectorHash));

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorTests.cs
@@ -53,7 +53,7 @@ public class VectorIndexCreationTests
             "Name", "TAG", "SEPARATOR", "|", 
             "Num", "NUMERIC",
             "SimpleHnswVector", "VECTOR", "HNSW", "6", "TYPE", "FLOAT64", "DIM", "10", "DISTANCE_METRIC", "L2",
-            "SimpleVectorizedVector.Vector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "30", "DISTANCE_METRIC", "L2"
+            "SimpleVectorizedVector.Vector", "AS", "SimpleVectorizedVector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "30", "DISTANCE_METRIC", "L2"
         );
     }
 


### PR DESCRIPTION
Minor fix to index creation for Hash fields (they need to alias `PropertyName.Vector` to `PropertyName` for queries to work correctly)