### PR TITLE
correcting unlink return type

### DIFF
--- a/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
+++ b/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.AllMiniLML6V2</RootNamespace>
-        <PackageVersion>0.6.1</PackageVersion>
-        <Version>0.6.1</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
+        <PackageVersion>0.7.0</PackageVersion>
+        <Version>0.7.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.7.0</PackageReleaseNotes>
         <Description>Sentence Vectorizer for Redis OM .NET using all-MiniLM-L6-v2</Description>
         <Title>Redis OM all-MiniLM-L6-v2 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
+++ b/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
@@ -4,9 +4,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.Resnet18</RootNamespace>
-        <PackageVersion>0.6.1</PackageVersion>
-        <Version>0.6.1</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
+        <PackageVersion>0.7.0</PackageVersion>
+        <Version>0.7.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.7.0</PackageReleaseNotes>
         <Description>Resnet 18 Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Resnet 18 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
+++ b/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM</RootNamespace>
-        <PackageVersion>0.6.1</PackageVersion>
-        <Version>0.6.1</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
+        <PackageVersion>0.7.0</PackageVersion>
+        <Version>0.7.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.7.0</PackageReleaseNotes>
         <Description>Core Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>0.6.1</PackageVersion>
-    <Version>0.6.1</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.6.1</PackageReleaseNotes>
+    <PackageVersion>0.7.0</PackageVersion>
+    <Version>0.7.0</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v0.7.0</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -740,7 +740,7 @@ namespace Redis.OM
         /// <param name="connection">the connection.</param>
         /// <param name="key">the key to unlink.</param>
         /// <returns>the status.</returns>
-        public static string Unlink(this IRedisConnection connection, string key) => connection.Execute("UNLINK", key);
+        public static long Unlink(this IRedisConnection connection, string key) => connection.Execute("UNLINK", key);
 
         /// <summary>
         /// Unlinks array of keys.
@@ -748,7 +748,7 @@ namespace Redis.OM
         /// <param name="connection">the connection.</param>
         /// <param name="keys">the keys to unlink.</param>
         /// <returns>the status.</returns>
-        public static string Unlink(this IRedisConnection connection, string[] keys) => connection.Execute("UNLINK", keys);
+        public static long Unlink(this IRedisConnection connection, string[] keys) => connection.Execute("UNLINK", keys);
 
         /// <summary>
         /// Unlinks a key.
@@ -756,7 +756,7 @@ namespace Redis.OM
         /// <param name="connection">the connection.</param>
         /// <param name="key">the key to unlink.</param>
         /// <returns>the status.</returns>
-        public static async Task<string> UnlinkAsync(this IRedisConnection connection, string key) => await connection.ExecuteAsync("UNLINK", key);
+        public static async Task<long> UnlinkAsync(this IRedisConnection connection, string key) => await connection.ExecuteAsync("UNLINK", key);
 
         /// <summary>
         /// Unlinks array of keys.
@@ -764,7 +764,7 @@ namespace Redis.OM
         /// <param name="connection">the connection.</param>
         /// <param name="keys">the keys to unlink.</param>
         /// <returns>the status.</returns>
-        public static async Task<string> UnlinkAsync(this IRedisConnection connection, string[] keys) => await connection.ExecuteAsync("UNLINK", keys);
+        public static async Task<long> UnlinkAsync(this IRedisConnection connection, string[] keys) => await connection.ExecuteAsync("UNLINK", keys);
 
         /// <summary>
         /// Unlinks the key and then adds an updated value of it.

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -479,5 +479,19 @@ namespace Redis.OM.Unit.Tests
             var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await collection.Take(10000).ToListAsync());
             Assert.Equal("Encountered timeout when searching - check the duration of your query.", ex.Message);
         }
+
+        [Fact]
+        public void TestUnlink()
+        {
+            string key1 = $"test:{Ulid.NewUlid()}";
+            string key2 = $"test:{Ulid.NewUlid()}";
+            var hostInfo = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost:6379";
+            var provider = new RedisConnectionProvider($"redis://{hostInfo}");
+            var connection = provider.Connection;
+            var res = connection.Unlink(key1);
+            Assert.Equal(0, res);
+            connection.Execute("SET", key1, "bar");
+            Assert.Equal(1,connection.Unlink(new []{key1, key2}));
+        }
     }
 }


### PR DESCRIPTION
Fixes #433

Unlink should return a long not a string (it does not get cast correctly). technically a breaking change so updating version as well.