### PR TITLE
Improved vector range argument parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We welcome code contributions from the community, if you want to contribute code
 1. Fork this repo.
 2. Make your Code Changes.
 3. Write your tests.
-4. Use the `docker run -p 6379:6379 redis/redis-stack-server` as your local environment for running the functional tests.
+4. Use the `docker run -p 6379:6379 redis/redis-stack-server` as your local environment for running the functional tests. (Note: If your tests fail due to missing vocabulary, please run `fetch.models.sh` from the root directory until Git LFS has been resolved. These files are required for the tokenizers used by the functional tests)
 5. Verify the tests pass (there may be a couple of deployment-specific tests (e.g. Sentinel/Cluster) in Redis.OM which will fail outside of the GH environment we've setup so don't worry about those).
 6. If it's your first time contributing please add your Github handle the the Contributors section in the README.
 7. Push your changes to GitHub.

--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@mdrakib](https://github.com/mdrakib)
 * [@jrpavoncello](https://github.com/jrpavoncello)
 * [@axnetg](https://github.com/axnetg)
+* [@abbottdev](https://github.com/abbottdev)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -1049,10 +1049,8 @@ namespace Redis.OM.Common
 
             var distance = exp.Arguments[2] switch
             {
-                UnaryExpression ue => (double)Expression.Lambda(ue).Compile().DynamicInvoke(),
                 ConstantExpression ce => (double)ce.Value,
-                MemberExpression me => (double)Expression.Lambda(me).Compile().DynamicInvoke(),
-                Expression e => throw new NotSupportedException($"Unsupported expression type: {e.NodeType}"),
+                Expression e => (double)Expression.Lambda(e).Compile().DynamicInvoke(),
                 _ => throw new ArgumentException("The expression at position [2] was not an expression"),
             };
 

--- a/test/Redis.OM.Vectorizer.Tests/VectorizerFunctionalTests.cs
+++ b/test/Redis.OM.Vectorizer.Tests/VectorizerFunctionalTests.cs
@@ -46,8 +46,7 @@ public class VectorizerFunctionalTests
             ImagePath = Vector.Of("hal.jpg")
         });
         
-        // int expression value being implicitly converted to a double yields a unary expression.
-        int variableRange = 5;
+        var variableRange = 5;
         var collection = new RedisCollection<DocWithVectors>(connection);
 
         // images
@@ -72,7 +71,7 @@ public class VectorizerFunctionalTests
             ImagePath = Vector.Of("hal.jpg")
         });
         
-        double variableRange = 5;
+        double variableRange = 5 + 5;
         var collection = new RedisCollection<DocWithVectors>(connection);
 
         // images
@@ -83,8 +82,35 @@ public class VectorizerFunctionalTests
         Assert.InRange(res.First().Scores!.RangeScore!.Value, 0, 1);
 
         // sentences
-        var knnRange = 5;
-        collection.NearestNeighbors(x => x.Sentence!, knnRange, "Hello world this really is Hal.");
+        collection.NearestNeighbors(x => x.Sentence!, 5, "Hello world this really is Hal.");
+    }
+
+    private static double GetVectorRange() => 5;
+    private static int GetKnnNeighbours() => 5;
+
+    [Fact]
+    public void VectorRangeMethodExpressionTest()
+    {
+        var connection = _provider.Connection;
+        connection.DropIndex(typeof(DocWithVectors));
+        connection.CreateIndex(typeof(DocWithVectors));
+        connection.Set(new DocWithVectors
+        {
+            Sentence = Vector.Of("Hello world this is Hal."),
+            ImagePath = Vector.Of("hal.jpg")
+        });
+        
+        var collection = new RedisCollection<DocWithVectors>(connection);
+
+        // images
+        
+        var res = collection.Where(x => x.Sentence!.VectorRange("Hal", GetVectorRange(), "score"));
+
+        Assert.NotNull(res.First().Scores!.RangeScore);
+        Assert.InRange(res.First().Scores!.RangeScore!.Value, 0, 1);
+
+        // sentences
+        collection.NearestNeighbors(x => x.Sentence!, GetKnnNeighbours(), "Hello world this really is Hal.");
     }
 
     [Fact]

--- a/test/Redis.OM.Vectorizer.Tests/VectorizerFunctionalTests.cs
+++ b/test/Redis.OM.Vectorizer.Tests/VectorizerFunctionalTests.cs
@@ -17,6 +17,7 @@ public class VectorizerFunctionalTests
     public void Test()
     {
         var connection = _provider.Connection;
+        connection.DropIndex(typeof(DocWithVectors));
         connection.CreateIndex(typeof(DocWithVectors));
         connection.Set(new DocWithVectors
         {
@@ -31,6 +32,59 @@ public class VectorizerFunctionalTests
         Assert.Equal(0, res.First().Scores!.NearestNeighborsScore);
         // sentences
         collection.NearestNeighbors(x => x.Sentence!, 5, "Hello world this really is Hal.");
+    }
+
+    [Fact]
+    public void VectorRangeUnaryExpressionTest()
+    {
+        var connection = _provider.Connection;
+        connection.DropIndex(typeof(DocWithVectors));
+        connection.CreateIndex(typeof(DocWithVectors));
+        connection.Set(new DocWithVectors
+        {
+            Sentence = Vector.Of("Hello world this is Hal."),
+            ImagePath = Vector.Of("hal.jpg")
+        });
+        
+        // int expression value being implicitly converted to a double yields a unary expression.
+        int variableRange = 5;
+        var collection = new RedisCollection<DocWithVectors>(connection);
+
+        // images
+        var res = collection.Where(x => x.Sentence!.VectorRange("Hal", variableRange, "score"));
+
+        Assert.NotNull(res.First().Scores!.RangeScore);
+        Assert.InRange(res.First().Scores!.RangeScore!.Value, 0, 1);
+
+        // sentences
+        collection.NearestNeighbors(x => x.Sentence!, variableRange, "Hello world this really is Hal.");
+    }
+
+    [Fact]
+    public void VectorRangeMemberExpressionTest()
+    {
+        var connection = _provider.Connection;
+        connection.DropIndex(typeof(DocWithVectors));
+        connection.CreateIndex(typeof(DocWithVectors));
+        connection.Set(new DocWithVectors
+        {
+            Sentence = Vector.Of("Hello world this is Hal."),
+            ImagePath = Vector.Of("hal.jpg")
+        });
+        
+        double variableRange = 5;
+        var collection = new RedisCollection<DocWithVectors>(connection);
+
+        // images
+        
+        var res = collection.Where(x => x.Sentence!.VectorRange("Hal", variableRange, "score"));
+
+        Assert.NotNull(res.First().Scores!.RangeScore);
+        Assert.InRange(res.First().Scores!.RangeScore!.Value, 0, 1);
+
+        // sentences
+        var knnRange = 5;
+        collection.NearestNeighbors(x => x.Sentence!, knnRange, "Hello world this really is Hal.");
     }
 
     [Fact]


### PR DESCRIPTION
When trying to use a `VectorRange` query using a non-constant value, an exception is thrown:
```
Exception has occurred: CLR/System.InvalidCastException
Exception thrown: 'System.InvalidCastException' in Redis.OM.dll: 'Unable to cast object of type 'System.Linq.Expressions.UnaryExpression' to type 'System.Linq.Expressions.ConstantExpression'.'
   at Redis.OM.Common.ExpressionParserUtilities.TranslateVectorRange(MethodCallExpression exp, List`1 parameters)
   at Redis.OM.Common.ExpressionParserUtilities.TranslateMethodExpressions(MethodCallExpression exp, List`1 parameters)
   at Redis.OM.Common.ExpressionTranslator.BuildQueryFromExpression(Expression exp, List`1 parameters)
   at Redis.OM.Common.ExpressionTranslator.TranslateWhereMethod(MethodCallExpression expression, List`1 parameters)
   at Redis.OM.Common.ExpressionTranslator.BuildQueryFromExpression(Expression expression, Type type, Expression mainBooleanExpression, Type rootType)
   at Redis.OM.Searching.RedisCollectionEnumerator`1..ctor(Expression exp, IRedisConnection connection, Int32 chunkSize, RedisCollectionStateManager stateManager, Expression`1 booleanExpression, Boolean saveState, Type rootType, Type type)
   at Redis.OM.Searching.RedisCollection`1.GetAsyncEnumerator(CancellationToken cancellationToken)
```

Support therefore needs to be added to evaluate the expression rather than being hardcoded to a constant expression. 

NB The Git LFS thing is still a rake that I stood on so I've included a note about running fetch-models until it's sorted :) 

Have run the docker instance locally and have passing tests:
```
Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5, Duration: 2 s - Redis.OM.Vectorizer.Tests.dll (net7.0)
Passed!  - Failed:     0, Passed:   504, Skipped:    11, Total:   515, Duration: 7 s - Redis.OM.Unit.Tests.dll (net6.0)
Passed!  - Failed:     0, Passed:   504, Skipped:    11, Total:   515, Duration: 7 s - Redis.OM.Unit.Tests.dll (net7.0)
```

Look forward to feedback!