### PR TITLE
Bugfix: support method call in Any() on embedded objects array

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@mdrakib](https://github.com/mdrakib)
 * [@jrpavoncello](https://github.com/jrpavoncello)
 * [@axnetg](https://github.com/axnetg)
+* [@PrudiusVladislav](https://github.com/PrudiusVladislav)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -960,8 +960,17 @@ namespace Redis.OM.Common
             var type = exp.Arguments.Last().Type;
             var prefix = GetOperandString(exp.Arguments[0]);
             var lambda = (LambdaExpression)exp.Arguments.Last();
-            var tempQuery = ExpressionTranslator.TranslateBinaryExpression((BinaryExpression)lambda.Body, parameters);
-            return tempQuery.Replace("@", $"{prefix}_");
+
+            if (lambda.Body is MethodCallExpression methodCall)
+            {
+                var tempQuery = TranslateMethodExpressions(methodCall, parameters);
+                return tempQuery.Replace("@", $"{prefix}_");
+            }
+            else
+            {
+                var tempQuery = ExpressionTranslator.TranslateBinaryExpression((BinaryExpression)lambda.Body, parameters);
+                return tempQuery.Replace("@", $"{prefix}_");
+            }
         }
 
         private static string ValueToString(object value)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2247,11 +2247,31 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             await collection.Where(x => 
                 x.Addresses.Any(a => a.City.Contains("Beach"))).ToListAsync();
+            await collection.Where(x =>
+                x.Addresses.Any(a => a.City.StartsWith("Satellite"))).ToListAsync();
+            await collection.Where(x =>
+                x.Addresses.Any(a => a.City.EndsWith("Beach"))).ToListAsync();
 
             await _substitute.Received().ExecuteAsync(
                 "FT.SEARCH",
                 "objectwithembeddedarrayofobjects-idx",
                 "(@Addresses_City:{*Beach*})",
+                "LIMIT",
+                "0",
+                "100");
+            
+            await _substitute.Received().ExecuteAsync(
+                "FT.SEARCH",
+                "objectwithembeddedarrayofobjects-idx",
+                "(@Addresses_City:{Satellite*})",
+                "LIMIT",
+                "0",
+                "100");
+            
+            await _substitute.Received().ExecuteAsync(
+                "FT.SEARCH",
+                "objectwithembeddedarrayofobjects-idx",
+                "(@Addresses_City:{*Beach})",
                 "LIMIT",
                 "0",
                 "100");

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -2238,6 +2238,26 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public async Task TestAnyQueryForArrayOfEmbeddedObjectsMethodCallExpression()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.ExecuteAsync(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<ObjectWithEmbeddedArrayOfObjects>(_substitute);
+
+            await collection.Where(x => 
+                x.Addresses.Any(a => a.City.Contains("Beach"))).ToListAsync();
+
+            await _substitute.Received().ExecuteAsync(
+                "FT.SEARCH",
+                "objectwithembeddedarrayofobjects-idx",
+                "(@Addresses_City:{*Beach*})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
         public async Task SearchWithMultipleWhereClauses()
         {
             _substitute.ClearSubstitute();


### PR DESCRIPTION
Solves #441, where `Any()` for embedded objects does not support method call expressions (e.g. `Contains()`, `StartsWith()` etc.). So, in addition to `BinaryExpression `translation support, added the handling of `MethodCallExpression `case. So, it would allow such constructions as, for example: `collection.Where(x => x.EmbeddedCollection.Any(a => a.Property.Contains("Value")))`. Previously, only basic BinaryExpressions like the equality check '==' were allowed.