### PR TITLE
fix: Casting to IQueryable no longer drops chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@axnetg](https://github.com/axnetg)
 * [@abbottdev](https://github.com/abbottdev)
 * [@PrudiusVladislav](https://github.com/PrudiusVladislav)
+* [@CormacLennon](https://github.com/CormacLennon)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -84,7 +84,11 @@ namespace Redis.OM.Searching
                    (IQueryable)Activator.CreateInstance(
                        typeof(RedisCollection<>).MakeGenericType(elementType),
                        this,
-                       expression);
+                       expression,
+                       StateManager,
+                       null,
+                       _saveState,
+                       _chunkSize);
             }
             catch (TargetInvocationException e)
             {
@@ -102,7 +106,7 @@ namespace Redis.OM.Searching
             where TElement : notnull
         {
             var booleanExpression = expression as Expression<Func<TElement, bool>>;
-            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, true);
+            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, true, _chunkSize);
         }
 
         /// <inheritdoc/>

--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -106,7 +106,7 @@ namespace Redis.OM.Searching
             where TElement : notnull
         {
             var booleanExpression = expression as Expression<Func<TElement, bool>>;
-            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, true, _chunkSize);
+            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, _saveState, _chunkSize);
         }
 
         /// <inheritdoc/>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -3822,5 +3822,22 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             Assert.Empty(people);
         }
+
+        [Fact]
+        public void TestBasicQueryCastToIQueryable()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+            var y = 33;
+            var collection = new RedisCollection<Person>(_substitute, 1234) as IQueryable<Person>;
+            _ = collection.Where(x => x.Age < y).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Age:[-inf (33])",
+                "LIMIT",
+                "0",
+                "1234");
+        }
     }
 }


### PR DESCRIPTION
Casting IRedisCollection to IQueryable no longer drops chunk size info for pagination.

Closes https://github.com/redis/redis-om-dotnet/issues/454