### PR TITLE
Fix Typo LANGUAGE_FIELD->LANGUAGE in SerializeIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@abbottdev](https://github.com/abbottdev)
 * [@PrudiusVladislav](https://github.com/PrudiusVladislav)
 * [@CormacLennon](https://github.com/CormacLennon)
+* [@ahmedisam99](https://github.com/ahmedisam99)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Modeling/RedisIndex.cs
+++ b/src/Redis.OM/Modeling/RedisIndex.cs
@@ -77,7 +77,7 @@ namespace Redis.OM.Modeling
 
             if (!string.IsNullOrEmpty(objAttribute.LanguageField))
             {
-                args.Add("LANGUAGE");
+                args.Add("LANGUAGE_FIELD");
                 args.Add(objAttribute.LanguageField!);
             }
 


### PR DESCRIPTION
Fix typo/bug in index serialization and creation which serializes `LanguageField` to `Language` instead of `Language_Field`