### PR TITLE
Fix bug in BuildEqualityPredicate

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -842,7 +842,7 @@ namespace Redis.OM.Common
                     sb.Append($"{{{ExpressionParserUtilities.EscapeTagField(right)}}}");
                     break;
                 case SearchFieldType.TEXT:
-                    sb.Append($"\"{right}\"");
+                    sb.Append($"{right}");
                     break;
                 case SearchFieldType.NUMERIC:
                     sb.Append($"[{right} {right}]");


### PR DESCRIPTION
When adding quotes to the predicate, redis throws/returns the following error:

```
"Invalid argument(s): Closing quote must be followed by a space or nothing at all."
```

This works ✅ :
`"FT.SEARCH" "idx" @Name:"Test"`

But this does not 🚫:
`"FT.SEARCH" "idx" (@Name:"Test")`

So I thought it would be safer to remove the quotes, since the query still works without them and it is already implemented in translating `string.Contains` (I actually fell back to using `string.Contains` because of this inconvenience)

Another thing to note that even though the mentioned query did not work and returned an error when running the command in redis-cli, the code did not throw an exception and just returned empty results