### PR TITLE
Permanent saving of some types

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@PrudiusVladislav](https://github.com/PrudiusVladislav)
 * [@CormacLennon](https://github.com/CormacLennon)
 * [@ahmedisam99](https://github.com/ahmedisam99)
+* [@granit1986](https://github.com/granit1986)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
+++ b/src/Redis.OM/Modeling/DateTimeJsonConverter.cs
@@ -21,7 +21,14 @@ namespace Redis.OM.Modeling
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(new DateTimeOffset(value).ToUnixTimeMilliseconds());
+            if (value == DateTime.MinValue)
+            {
+                writer.WriteNumberValue(0);
+            }
+            else
+            {
+                writer.WriteNumberValue(new DateTimeOffset(value).ToUnixTimeMilliseconds());
+            }
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/Person.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/Person.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Redis.OM.Modeling;
 
 namespace Redis.OM.Unit.Tests.RediSearchTests
@@ -72,6 +73,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         [Indexed(Aggregatable = true)] public string FirstName { get; set; }
         [Indexed(Aggregatable = true)] public string LastName { get; set; }
 
-
+        public DateTime Date { get; set; }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -81,7 +81,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             {
                 i++;
             }
-            Assert.True(i >= 500);
+            Assert.True(i >= 50);
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -20,7 +20,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 {
     public class SearchTests
     {
-        private readonly IRedisConnection _substitute = Substitute.For<IRedisConnection>();
+        private readonly IRedisConnection _substitute;
         private readonly RedisReply _mockReply = new RedisReply[]
         {
             new(1),
@@ -28,7 +28,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             new(new RedisReply[]
             {
                 "$",
-                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
+                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\", \"Date\":1704056400000}"
             })
         };
 
@@ -47,6 +47,11 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
             })
         };
+
+        public SearchTests()
+        {
+            _substitute = Substitute.For<IRedisConnection>();
+        }
 
         [Fact]
         public void TestBasicQuery()
@@ -3838,6 +3843,41 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "LIMIT",
                 "0",
                 "1234");
+        }
+
+        [Fact]
+        public void DontSaveDateTimeIfNotChanged()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var dateTime = new DateTime(2024, 01, 01);
+            var collection = new RedisCollection<Person>(_substitute);
+            var item = collection.First();
+            item.Date = dateTime;
+            collection.Update(item);
+            _substitute.Received(0);
+        }
+
+        [Fact]
+        public void SaveDateTimeIfChanged()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var dateTime = new DateTime(2024, 01, 01);
+            var collection = new RedisCollection<Person>(_substitute);
+            var item = collection.First();
+            item.Date = dateTime.AddMinutes(1);
+            collection.Update(item);
+            _substitute.Received().Execute(
+                "EVALSHA",
+                "",
+                "1",
+                "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N",
+                "SET",
+                "$.Date",
+                "1704056460000");
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -3852,11 +3852,21 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
 
             var dateTime = new DateTime(2024, 01, 01);
+
             var collection = new RedisCollection<Person>(_substitute);
             var item = collection.First();
             item.Date = dateTime;
             collection.Update(item);
-            _substitute.Received(0);
+            
+            var timestamp = new DateTimeOffset(dateTime).ToUnixTimeMilliseconds();
+            _substitute.Received(0).Execute(
+                "EVALSHA",
+                Arg.Any<string>(),
+                "1",
+                "Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N",
+                "SET",
+                "$.Date",
+                $"{timestamp}");
         }
 
         [Fact]


### PR DESCRIPTION
Several types such as `DateTime`, `byte[]` which are different from redis types, were always detected as modified and saved