### PR TITLE
feat: Add the ability to compare existing index definitions to the projected one for a type

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,4 +14,4 @@ jobs:
       - name: fetch-models
         run: sh fetch-models.sh
       - name: execute
-        run: docker-compose -f ./docker/docker-compose.yaml run dotnet
+        run: docker compose -f ./docker/docker-compose.yaml run dotnet

--- a/README.md
+++ b/README.md
@@ -107,18 +107,17 @@ var provider = new RedisConnectionProvider("redis://localhost:6379");
 provider.Connection.CreateIndex(typeof(Customer));
 ```
 
-Redis OM provides limited support for schema and data migration at this time. We provide a small extension method `IndexDefinitionEquals` on the `RedisIndexInfo` type that you may opt in to use to determine when to re-create your indexes when your types change. An example implementation of this would look like:
+Redis OM provides limited support for schema migration at this time. You can check if the index definition in Redis matches your current index definition using the `IsIndexCurrent` method on the `RedisConnection`. Then you may use that output to determine when to re-create your indexes when your types change. An example implementation of this would look like:
 
 ```csharp
 var provider = new RedisConnectionProvider("redis://localhost:6379");
 var definition = provider.Connection.GetIndexInfo(typeof(Customer));
 
-if (definition.IndexDefinitionEquals(typeof(Customer)) == false)
+if (!provider.Connection.IsIndexCurrent(typeof(Customer)))
 {
     provider.Connection.DropIndex(typeof(Customer));
+    provider.Connection.CreateIndex(typeof(Customer));
 }
-
-provider.Connection.CreateIndex(typeof(Customer));
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ var provider = new RedisConnectionProvider("redis://localhost:6379");
 provider.Connection.CreateIndex(typeof(Customer));
 ```
 
+Redis OM provides limited support for schema and data migration at this time. We provide a small extension method `IndexDefinitionEquals` on the `RedisIndexInfo` type that you may opt in to use to determine when to re-create your indexes when your types change. An example implementation of this would look like:
+
+```csharp
+var provider = new RedisConnectionProvider("redis://localhost:6379");
+var definition = provider.Connection.GetIndexInfo(typeof(Customer));
+
+if (definition.IndexDefinitionEquals(typeof(Customer)) == false)
+{
+    provider.Connection.DropIndex(typeof(Customer));
+}
+
+provider.Connection.CreateIndex(typeof(Customer));
+```
+
+
 ### Indexing Embedded Documents
 
 There are two methods for indexing embedded documents with Redis.OM, an embedded document is a complex object, e.g. if our `Customer` model had an `Address` property with the following model:

--- a/src/Redis.OM/RediSearchCommands.cs
+++ b/src/Redis.OM/RediSearchCommands.cs
@@ -178,7 +178,7 @@ namespace Redis.OM
             try
             {
                 var indexName = type.SerializeIndex().First();
-                var redisReply = await connection.ExecuteAsync("FT.INFO", indexName);
+                var redisReply = await connection.ExecuteAsync("FT.INFO", indexName).ConfigureAwait(false);
                 var redisIndexInfo = new RedisIndexInfo(redisReply);
                 return redisIndexInfo;
             }
@@ -266,6 +266,30 @@ namespace Redis.OM
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Check if the index exists and is up to date.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="type">The type the index was built from.</param>
+        /// <returns>Whether or not the index is current.</returns>
+        public static bool IsIndexCurrent(this IRedisConnection connection, Type type)
+        {
+            var definition = connection.GetIndexInfo(type);
+            return definition?.IndexDefinitionEquals(type) ?? false;
+        }
+
+        /// <summary>
+        /// Check if the index exists and is up to date.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="type">The type the index was built from.</param>
+        /// <returns>Whether or not the index is current.</returns>
+        public static async Task<bool> IsIndexCurrentAsync(this IRedisConnection connection, Type type)
+        {
+            var definition = await connection.GetIndexInfoAsync(type).ConfigureAwait(false);
+            return definition?.IndexDefinitionEquals(type) ?? false;
         }
 
         /// <summary>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
@@ -218,6 +218,34 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestCheckIndexUpToDate()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            connection.DropIndex(typeof(SerialisedJsonType));
+            Assert.False(connection.IsIndexCurrent(typeof(SerialisedJsonType)));
+
+            connection.CreateIndex(typeof(SerialisedJsonType));
+            Assert.False(connection.IsIndexCurrent(typeof(SerialisedJsonTypeNotMatch)));
+            Assert.True(connection.IsIndexCurrent(typeof(SerialisedJsonType)));
+        }
+
+        [Fact]
+        public async Task TestCheckIndexUpToDateAsync()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+            await connection.DropIndexAsync(typeof(SerialisedJsonType));
+            Assert.False(await connection.IsIndexCurrentAsync(typeof(SerialisedJsonType)));
+
+            await connection.CreateIndexAsync(typeof(SerialisedJsonType));
+            Assert.False(await connection.IsIndexCurrentAsync(typeof(SerialisedJsonTypeNotMatch)));
+            Assert.True(await connection.IsIndexCurrentAsync(typeof(SerialisedJsonType)));
+        }
+
+        [Fact]
         public async Task TestGetIndexInfoWhichDoesNotExistAsync()
         {
             var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Redis.OM.Contracts;
 using Redis.OM.Modeling;
 using Xunit;
 
@@ -18,6 +19,34 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             public int Age { get; set; }
             public double Height { get; set; }
             public string[] NickNames { get; set; }
+        }
+
+        [Document(IndexName = "TestPersonClassHappyPath-idx", Prefixes = new []{"Simple"}, StorageType = StorageType.Hash)]
+        public class TestPersonClassHappyPathWithMutatedDefinition
+        {
+            public string Name { get; set; }
+            [Indexed(Sortable = true)]
+            public int Age { get; set; }
+            public double Height { get; set; }
+        }
+
+        [Document(IndexName = "SerialisedJson-idx", Prefixes = new []{"Simple"}, StorageType = StorageType.Json)]
+        public class SerialisedJsonType
+        {
+            [Searchable(Sortable = true)]
+            public string Name { get; set; }
+            
+            public int Age { get; set; }
+        }
+
+        [Document(IndexName = "SerialisedJson-idx", Prefixes = new []{"Simple"}, StorageType = StorageType.Json)]
+        public class SerialisedJsonTypeNotMatch
+        {
+            [Searchable(Sortable = true)]
+            public string Name { get; set; }
+            
+            [Indexed(Sortable = true)]
+            public int Age { get; set; }
         }
 
         [Document(IndexName = "TestPersonClassHappyPath-idx", StorageType = StorageType.Hash, Prefixes = new []{"Person:"})]
@@ -197,6 +226,36 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
             var indexInfo = await connection.GetIndexInfoAsync(typeof(TestPersonClassHappyPath));
             Assert.Null(indexInfo);
+        }
+
+        [Fact]
+        public async Task TestGetIndexInfoWhichDoesNotMatchExisting()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+
+            await connection.DropIndexAsync(typeof(TestPersonClassHappyPath));
+            await connection.CreateIndexAsync(typeof(TestPersonClassHappyPath));
+            var indexInfo = await connection.GetIndexInfoAsync(typeof(TestPersonClassHappyPath));
+
+            Assert.False(indexInfo.IndexDefinitionEquals(typeof(TestPersonClassHappyPathWithMutatedDefinition)));
+            Assert.True(indexInfo.IndexDefinitionEquals(typeof(TestPersonClassHappyPath)));
+        }
+
+        [Fact]
+        public async Task TestGetIndexInfoWhichDoesNotMatchExistingJson()
+        {
+            var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";
+            var provider = new RedisConnectionProvider($"redis://{host}");
+            var connection = provider.Connection;
+
+            await connection.DropIndexAsync(typeof(SerialisedJsonType));
+            await connection.CreateIndexAsync(typeof(SerialisedJsonType));
+            var indexInfo = await connection.GetIndexInfoAsync(typeof(SerialisedJsonType));
+
+            Assert.False(indexInfo.IndexDefinitionEquals(typeof(SerialisedJsonTypeNotMatch)));
+            Assert.True(indexInfo.IndexDefinitionEquals(typeof(SerialisedJsonType)));
         }
     }
 }


### PR DESCRIPTION
Hi @slorello89,

This PR adds support to be able to have a _VERY_ simple mechanism for the consumer of the library to determine if they need to drop/recreate a given index.

I foresee people using this method like this pseudocode Index drop/create is async I believe, so the consumer would need to do their own polling to wait for the index to properly delete first but:
```csharp
var provider = new RedisConnectionProvider("redis://localhost:6379");
var definition = provider.Connection.GetIndexInfo(typeof(Customer));

if (definition.IndexDefinitionEquals(typeof(Customer)) == false)
{
    provider.Connection.DropIndex(typeof(Customer));
}

provider.Connection.CreateIndex(typeof(Customer));
```

Please forgive me that I've not raised an issue for this beforehand - I'm hoping this PR makes enough sense for us to discuss here.

Rather than making all the internals of `RedisIndex` visible, I've added an extension method that can be used to compare index definitions. 

Happy to discuss implementation/naming/test coverage but figure it's easier to discuss something visual.

**EDIT**: First run of the action failed, looks like `ubuntu-latest` has moved on to use `docker compose` over `docker-compose` (v2) now.

