### PR TITLE
Use 'InvariantCulture' when converting the UNIX timestamp to string

### DIFF
--- a/src/Redis.OM/RedisObjectHandler.cs
+++ b/src/Redis.OM/RedisObjectHandler.cs
@@ -371,7 +371,7 @@ namespace Redis.OM
                     var val = (DateTime)property.GetValue(obj);
                     if (val != default)
                     {
-                        hash.Add(propertyName, new DateTimeOffset(val).ToUnixTimeMilliseconds().ToString());
+                        hash.Add(propertyName, new DateTimeOffset(val).ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
                     }
                 }
                 else if (type == typeof(Vector))


### PR DESCRIPTION
In some cases (like mine) when the current culture is RTL (e.g. Arabic) and when converting a DateTime that is before the UNIX epoch it results a incorrectly formatted negative string.

```
// english culture
"07-15-1953" -> "-519616800000"

// arabic culture
"07-15-1953" -> "519616800000-"
```

Which causes issues when trying to update the value in redis