### PR TITLE
fix: When using AllMiniLML6V2 vectorizer, inference sessions would be…

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,4 +14,4 @@ jobs:
       - name: fetch-models
         run: sh fetch-models.sh
       - name: execute
-        run: docker-compose -f ./docker/docker-compose.yaml run dotnet
+        run: docker compose -f ./docker/docker-compose.yaml run dotnet

--- a/src/Redis.OM.Vectorizers.AllMiniLML6V2/SentenceVectorizer.cs
+++ b/src/Redis.OM.Vectorizers.AllMiniLML6V2/SentenceVectorizer.cs
@@ -17,8 +17,8 @@ public class SentenceVectorizer : IVectorizer<string>
 
     /// <inheritdoc />
     public int Dim => 384;
-    private static Lazy<TokenizerBase> Tokenizer => new Lazy<TokenizerBase>(AllMiniLML6V2Tokenizer.Create);
-    private static Lazy<InferenceSession> InferenceSession => new Lazy<InferenceSession>(LoadInferenceSession);
+    private static readonly Lazy<TokenizerBase> Tokenizer = new(AllMiniLML6V2Tokenizer.Create);
+    private static readonly Lazy<InferenceSession> InferenceSession = new(LoadInferenceSession);
 
     private static InferenceSession LoadInferenceSession()
     {
@@ -40,7 +40,7 @@ public class SentenceVectorizer : IVectorizer<string>
         return Vectorize(new[] { obj })[0].SelectMany(BitConverter.GetBytes).ToArray();
     }
 
-     private static Lazy<string[]> OutputNames => new (() => InferenceSession.Value.OutputMetadata.Keys.ToArray());
+     private static readonly Lazy<string[]> OutputNames = new (() => InferenceSession.Value.OutputMetadata.Keys.ToArray());
 
     /// <summary>
     /// Vectorizers an array of sentences (which are vectorized individually).


### PR DESCRIPTION
… created for each call to Vectorize as the field was an expression bodied member, resulting in a new creation of a Lazy instance each time.