### PR TITLE
Add ToQueryString method to RedisCollection, RedisAggregationSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ We'd love your contributions! If you want to contribute please read our [Contrib
 * [@CormacLennon](https://github.com/CormacLennon)
 * [@ahmedisam99](https://github.com/ahmedisam99)
 * [@kirollosonsi](https://github.com/kirollosonsi)
+* [@tgmoore](https://github.com/tgmoore)
 
 <!-- Logo -->
 [Logo]: images/logo.svg

--- a/src/Redis.OM/Aggregation/RedisAggregationSet.cs
+++ b/src/Redis.OM/Aggregation/RedisAggregationSet.cs
@@ -117,7 +117,7 @@ namespace Redis.OM.Aggregation
             => (await ToListAsync()).ToArray();
 
         /// <summary>
-        /// A string representation of the aggregation command and parameters, a serialization of the Expression.
+        /// A string representation of the aggregation command and parameters, a serialization of the Expression with all parameters explicitly quoted.
         /// Warning: this string may not be suitable for direct execution and is intended only for use in debugging.
         /// </summary>
         /// <returns>A string representing the Expression serialized to an aggregation command and parameters.</returns>
@@ -132,7 +132,9 @@ namespace Redis.OM.Aggregation
                 serializedArgs.Add(_chunkSize.ToString());
             }
 
-            return $"FT.AGGREGATE {string.Join(" ", serializedArgs)}";
+            var quotedArgs = serializedArgs.Select(arg => $"\"{arg}\"");
+
+            return $"\"FT.AGGREGATE\" {string.Join(" ", quotedArgs)}";
         }
 
         private void Initialize(RedisQueryProvider provider, Expression? expression, bool useCursor)

--- a/src/Redis.OM/Aggregation/RedisAggregationSet.cs
+++ b/src/Redis.OM/Aggregation/RedisAggregationSet.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Redis.OM.Common;
 using Redis.OM.Contracts;
 using Redis.OM.Modeling;
 using Redis.OM.Searching;
@@ -114,6 +115,25 @@ namespace Redis.OM.Aggregation
         /// <returns>a task that will resolve when the array is enumerated.</returns>
         public async ValueTask<AggregationResult<T>[]> ToArrayAsync()
             => (await ToListAsync()).ToArray();
+
+        /// <summary>
+        /// A string representation of the aggregation command and parameters, a serialization of the Expression.
+        /// Warning: this string may not be suitable for direct execution and is intended only for use in debugging.
+        /// </summary>
+        /// <returns>A string representing the Expression serialized to an aggregation command and parameters.</returns>
+        public string ToQueryString()
+        {
+            var serializedArgs = ExpressionTranslator.BuildAggregationFromExpression(Expression, typeof(T)).Serialize().ToList();
+
+            if (_useCursor)
+            {
+                serializedArgs.Add("WITHCURSOR");
+                serializedArgs.Add("COUNT");
+                serializedArgs.Add(_chunkSize.ToString());
+            }
+
+            return $"FT.AGGREGATE {string.Join(" ", serializedArgs)}";
+        }
 
         private void Initialize(RedisQueryProvider provider, Expression? expression, bool useCursor)
         {

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -339,5 +339,12 @@ namespace Redis.OM.Searching
         /// <param name="ids">The Ids to look up.</param>
         /// <returns>A dictionary correlating the ids provided to the objects in Redis.</returns>
         Task<IDictionary<string, T?>> FindByIdsAsync(IEnumerable<string> ids);
+
+        /// <summary>
+        /// A string representation of the Redisearch command and parameters, a serialization of the Expression.
+        /// Warning: this string may not be suitable for direct execution and is intended only for use in debugging.
+        /// </summary>
+        /// <returns>A string representing the Expression serialized to a Redisearch command and parameters.</returns>
+        string ToQueryString();
     }
 }

--- a/src/Redis.OM/Searching/IRedisCollection.cs
+++ b/src/Redis.OM/Searching/IRedisCollection.cs
@@ -341,7 +341,7 @@ namespace Redis.OM.Searching
         Task<IDictionary<string, T?>> FindByIdsAsync(IEnumerable<string> ids);
 
         /// <summary>
-        /// A string representation of the Redisearch command and parameters, a serialization of the Expression.
+        /// A string representation of the Redisearch command and parameters, a serialization of the Expression with all parameters explicitly quoted.
         /// Warning: this string may not be suitable for direct execution and is intended only for use in debugging.
         /// </summary>
         /// <returns>A string representing the Expression serialized to a Redisearch command and parameters.</returns>

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -736,7 +736,10 @@ namespace Redis.OM.Searching
         {
             var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T), BooleanExpression, RootType);
             query.Limit ??= new SearchLimit { Number = ChunkSize, Offset = 0 };
-            return $"FT.SEARCH {string.Join(" ", query.SerializeQuery())}";
+
+            var quotedArgs = query.SerializeQuery().Select(arg => $"\"{arg}\"");
+
+            return $"\"FT.SEARCH\" {string.Join(" ", quotedArgs)}";
         }
 
         private static MethodInfo GetMethodInfo<T1, T2>(Func<T1, T2> f, T1 unused)

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -731,6 +731,14 @@ namespace Redis.OM.Searching
             return new RedisCollectionEnumerator<T>(Expression, provider.Connection, ChunkSize, StateManager, BooleanExpression, SaveState, RootType, typeof(T));
         }
 
+        /// <inheritdoc/>
+        public string ToQueryString()
+        {
+            var query = ExpressionTranslator.BuildQueryFromExpression(Expression, typeof(T), BooleanExpression, RootType);
+            query.Limit ??= new SearchLimit { Number = ChunkSize, Offset = 0 };
+            return $"FT.SEARCH {string.Join(" ", query.SerializeQuery())}";
+        }
+
         private static MethodInfo GetMethodInfo<T1, T2>(Func<T1, T2> f, T1 unused)
         {
             return f.Method;

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -664,7 +664,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         public void TestToQueryString()
         {
             var collection = new RedisAggregationSet<Person>(_substitute, true, chunkSize: 10000);
-            var command = "FT.AGGREGATE person-idx @Salary:[(30.55 inf] LOAD * APPLY @Address_HouseNumber + 4 AS house_num_modified SORTBY 2 @Age DESC LIMIT 0 10 WITHCURSOR COUNT 10000";
+            var command = "\"FT.AGGREGATE\" \"person-idx\" \"@Salary:[(30.55 inf]\" \"LOAD\" \"*\" \"APPLY\" \"@Address_HouseNumber + 4\" \"AS\" \"house_num_modified\" \"SORTBY\" \"2\" \"@Age\" \"DESC\" \"LIMIT\" \"0\" \"10\" \"WITHCURSOR\" \"COUNT\" \"10000\"";
 
             var queryString = collection
                 .LoadAll()

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -3894,7 +3894,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         public void TestToQueryString()
         {
             _substitute.ClearSubstitute();
-            string command = "FT.SEARCH person-idx (((@Name:Ste) | (@Height:[70 inf])) (@Age:[-inf (33])) LIMIT 100 10 SORTBY Age ASC";
+            var command = "\"FT.SEARCH\" \"person-idx\" \"(((@Name:Ste) | (@Height:[70 inf])) (@Age:[-inf (33]))\" \"LIMIT\" \"100\" \"10\" \"SORTBY\" \"Age\" \"ASC\"";
 
             var collection = new RedisCollection<Person>(_substitute);
             var queryString = collection.Where(x => x.Name.Contains("Ste") || x.Height >= 70).Where(x => x.Age < 33).OrderBy(x => x.Age).Skip(100).Take(10).ToQueryString();

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -3889,5 +3889,17 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100");
         }
+        
+        [Fact]
+        public void TestToQueryString()
+        {
+            _substitute.ClearSubstitute();
+            string command = "FT.SEARCH person-idx (((@Name:Ste) | (@Height:[70 inf])) (@Age:[-inf (33])) LIMIT 100 10 SORTBY Age ASC";
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var queryString = collection.Where(x => x.Name.Contains("Ste") || x.Height >= 70).Where(x => x.Age < 33).OrderBy(x => x.Age).Skip(100).Take(10).ToQueryString();
+
+            Assert.Equal(command, queryString);
+        }
     }
 }


### PR DESCRIPTION
Exposes ToQueryString from RedisCollection and RedisAggregationSet.

Resolves #486

The following questions came up while putting this together:

1. Is `ToQueryString` a reasonable name? Is `ToCommandString` more accurate for Redisearch?
2. These methods duplicate behavior found in `AggregationEnumerator.SerializedArgs` and `RedisCollectionEnumerator.RedisCollectionEnumerator`. Is that reasonable, or should there be a common source for that behavior?
3. Should the tests cover less RedisCollection/RedisAggregationSet behavior and just do the least amount necessary to serialize the command to a string?