### PR TITLE
fixing multiple match predicates query parsing issue

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -664,6 +664,10 @@ namespace Redis.OM.Common
             return exp.Method.Name switch
             {
                 nameof(StringExtension.FuzzyMatch) => TranslateFuzzyMatch(exp),
+                nameof(StringExtension.MatchContains) => TranslateMatchContains(exp),
+                nameof(StringExtension.MatchStartsWith) => TranslateMatchStartsWith(exp),
+                nameof(StringExtension.MatchEndsWith) => TranslateEndsWith(exp),
+                nameof(StringExtension.MatchPattern) => TranslateMatchPattern(exp),
                 nameof(string.Format) => TranslateFormatMethodStandardQuerySyntax(exp),
                 nameof(string.Contains) => TranslateContainsStandardQuerySyntax(exp, parameters),
                 nameof(string.StartsWith) => TranslateStartsWith(exp),

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -415,6 +415,23 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100");
         }
+        
+        [Fact]
+        public void TestMultipleMatches()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.Name.MatchContains("Ste") && x.Name.MatchStartsWith("Stev") && x.Name.MatchEndsWith("eve") && x.Name.MatchPattern("%Stepe%")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "((((@Name:*Ste*) (@Name:Stev*)) (@Name:*eve)) (@Name:%Stepe%))",
+                "LIMIT",
+                "0",
+                "100");
+        }
 
         [Fact]
         public void TestMatchPattern()


### PR DESCRIPTION
Fixes #481 - issue was that one of the methods that breaks down matching queries was not set up to handle the new match methods.