### PR TITLE
Bugfix/comprehensive index equality

### DIFF
--- a/src/Redis.OM/Modeling/RedisIndex.cs
+++ b/src/Redis.OM/Modeling/RedisIndex.cs
@@ -117,6 +117,12 @@ namespace Redis.OM.Modeling
                     attr.Add("AS");
                 }
 
+                if (!isJson && a.Type is not null && a.Type == "VECTOR")
+                {
+                    attr.Add($"{a.Attribute!}.Vector");
+                    attr.Add("AS");
+                }
+
                 attr.Add(a.Attribute!);
 
                 if (a.Type != null)

--- a/src/Redis.OM/RedisIndexInfo.cs
+++ b/src/Redis.OM/RedisIndexInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Redis.OM.Modeling;
 
 namespace Redis.OM
 {
@@ -220,6 +221,9 @@ namespace Redis.OM
                         case "key_type": Identifier = value.ToString(CultureInfo.InvariantCulture); break;
                         case "prefixes": Prefixes = value.ToArray().Select(x => x.ToString(CultureInfo.InvariantCulture)).ToArray(); break;
                         case "default_score": DefaultScore = value.ToString(CultureInfo.InvariantCulture); break;
+                        case "default_language": DefaultLanguage = value.ToString(CultureInfo.InvariantCulture); break;
+                        case "filter": Filter = value.ToString(CultureInfo.InvariantCulture); break;
+                        case "language_field": LanguageField = value.ToString(CultureInfo.InvariantCulture); break;
                     }
                 }
             }
@@ -238,6 +242,21 @@ namespace Redis.OM
             /// Gets default_score.
             /// </summary>
             public string? DefaultScore { get; }
+
+            /// <summary>
+            /// Gets Filter.
+            /// </summary>
+            public string? Filter { get; }
+
+            /// <summary>
+            /// Gets language.
+            /// </summary>
+            public string? DefaultLanguage { get; }
+
+            /// <summary>
+            /// Gets LanguageField.
+            /// </summary>
+            public string? LanguageField { get; }
         }
 
         /// <summary>
@@ -266,7 +285,19 @@ namespace Redis.OM
                         case "attribute": Attribute = value; break;
                         case "type": Type = value; break;
                         case "SEPARATOR": Separator = value; break;
+                        case "algorithm": Algorithm = value; break;
+                        case "data_type": VectorType = value; break;
+                        case "dim": Dimension = value; break;
+                        case "distance_metric": DistanceMetric = value; break;
+                        case "M": M = value; break;
+                        case "ef_construction": EfConstruction = value; break;
+                        case "WEIGHT": Weight = value; break;
                     }
+                }
+
+                if (responseArray.Any(x => ((string)x).Equals("NOSTEM", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    NoStem = true;
                 }
 
                 if (responseArray.Select(x => x.ToString())
@@ -300,6 +331,46 @@ namespace Redis.OM
             /// Gets SORTABLE.
             /// </summary>
             public bool? Sortable { get; }
+
+            /// <summary>
+            /// Gets NOSTEM.
+            /// </summary>
+            public bool? NoStem { get; }
+
+            /// <summary>
+            /// Gets weight.
+            /// </summary>
+            public string? Weight { get; }
+
+            /// <summary>
+            /// Gets Algorithm.
+            /// </summary>
+            public string? Algorithm { get; }
+
+            /// <summary>
+            /// Gets the VectorType.
+            /// </summary>
+            public string? VectorType { get; }
+
+            /// <summary>
+            /// Gets Dimension.
+            /// </summary>
+            public string? Dimension { get; }
+
+            /// <summary>
+            /// Gets DistanceMetric.
+            /// </summary>
+            public string? DistanceMetric { get; }
+
+            /// <summary>
+            /// Gets M.
+            /// </summary>
+            public string? M { get; }
+
+            /// <summary>
+            /// Gets EF constructor.
+            /// </summary>
+            public string? EfConstruction { get; }
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #494 

#479 added support for checking the equality of the current state of your model in your code versus what is in Redis, however there are a number of cases it did not account for which I missed during my review (e.g Vector fields, the special arguments from text fields, special arguments in the Document Attribute) one of which someone tripped over in #494. This PR should address all of these.

There is still the special case where it will not be able to definitively tell whether or not a index definition matches as several fields from the index definition are not returned from FT.INFO, namely `STOPWORDS`, `PHONETIC`, `EF_RUNTIME`, `EPSILON`,  in which ase Redis OM will simply throw an `ArgumentException`.