### PR TITLE
fixing issue with timespans having fractional millisecond values

### DIFF
--- a/src/Redis.OM/Extensions/TimespanExtensions.cs
+++ b/src/Redis.OM/Extensions/TimespanExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+
+namespace Redis.OM;
+
+/// <summary>
+/// Extension methods for Timespans.
+/// </summary>
+internal static class TimespanExtensions
+{
+    /// <summary>
+    /// Rounds up total milliseconds as an integer.
+    /// </summary>
+    /// <param name="ts">the timespan.</param>
+    /// <returns>the rounded timespan milliseconds.</returns>
+    public static string TotalMillisecondsString(this TimeSpan ts)
+    {
+        return Math.Ceiling(ts.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Redis.OM/RedisCommands.cs
+++ b/src/Redis.OM/RedisCommands.cs
@@ -187,7 +187,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static async Task<bool> JsonSetAsync(this IRedisConnection connection, string key, string path, string json, WhenKey when, TimeSpan? timeSpan = null)
         {
-            var argList = new List<string> { timeSpan != null ? ((long)timeSpan.Value.TotalMilliseconds).ToString() : "-1", path, json };
+            var argList = new List<string> { timeSpan != null ? timeSpan.Value.TotalMillisecondsString() : "-1", path, json };
             switch (when)
             {
                 case WhenKey.Exists:
@@ -328,7 +328,7 @@ namespace Redis.OM
         /// <returns>whether the operation succeeded.</returns>
         public static bool JsonSet(this IRedisConnection connection, string key, string path, string json, WhenKey when, TimeSpan? timeSpan = null)
         {
-            var argList = new List<string> { timeSpan != null ? ((long)timeSpan.Value.TotalMilliseconds).ToString() : "-1", path, json };
+            var argList = new List<string> { timeSpan != null ? timeSpan.Value.TotalMillisecondsString() : "-1", path, json };
             switch (when)
             {
                 case WhenKey.Exists:
@@ -416,7 +416,7 @@ namespace Redis.OM
                 var kvps = obj.BuildHashSet();
                 var argsList = new List<object>();
                 int? res = null;
-                argsList.Add(timespan != null ? ((long)timespan.Value.TotalMilliseconds).ToString() : "-1");
+                argsList.Add(timespan != null ? timespan.Value.TotalMillisecondsString() : "-1");
                 foreach (var kvp in kvps)
                 {
                     argsList.Add(kvp.Key);
@@ -467,7 +467,7 @@ namespace Redis.OM
                 var kvps = obj.BuildHashSet();
                 var argsList = new List<object>();
                 int? res = null;
-                argsList.Add(timespan != null ? ((long)timespan.Value.TotalMilliseconds).ToString() : "-1");
+                argsList.Add(timespan != null ? timespan.Value.TotalMillisecondsString() : "-1");
                 foreach (var kvp in kvps)
                 {
                     argsList.Add(kvp.Key);
@@ -794,8 +794,8 @@ namespace Redis.OM
                     args.Add(pair.Value);
                     if (ttl is not null)
                     {
-                        args.Add("EXPIRE");
-                        args.Add(ttl.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                        args.Add("PEXPIRE");
+                        args.Add(ttl.Value.TotalMillisecondsString());
                     }
                 }
 
@@ -831,8 +831,8 @@ namespace Redis.OM
                     args.Add(pair.Value);
                     if (ttl is not null)
                     {
-                        args.Add("EXPIRE");
-                        args.Add(ttl.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                        args.Add("PEXPIRE");
+                        args.Add(ttl.Value.TotalMillisecondsString());
                     }
                 }
 
@@ -848,7 +848,7 @@ namespace Redis.OM
             TimeSpan ts)
         {
             var commandTuple = Tuple.Create(command, args);
-            var expireTuple = Tuple.Create("PEXPIRE", new object[] { new RedisKey(keyToExpire), ((long)ts.TotalMilliseconds).ToString(CultureInfo.InvariantCulture) });
+            var expireTuple = Tuple.Create("PEXPIRE", new object[] { new RedisKey(keyToExpire), ts.TotalMillisecondsString() });
             return connection.ExecuteInTransaction(new[] { commandTuple, expireTuple });
         }
 
@@ -860,7 +860,7 @@ namespace Redis.OM
             TimeSpan ts)
         {
             var commandTuple = Tuple.Create(command, args);
-            var expireTuple = Tuple.Create("PEXPIRE", new object[] { new RedisKey(keyToExpire), ((long)ts.TotalMilliseconds).ToString(CultureInfo.InvariantCulture) });
+            var expireTuple = Tuple.Create("PEXPIRE", new object[] { new RedisKey(keyToExpire), ts.TotalMillisecondsString() });
             return connection.ExecuteInTransactionAsync(new[] { commandTuple, expireTuple });
         }
     }

--- a/src/Redis.OM/Searching/RedisCollection.cs
+++ b/src/Redis.OM/Searching/RedisCollection.cs
@@ -773,14 +773,14 @@ namespace Redis.OM.Searching
                     if (ttl is not null)
                     {
                         args.Add("EXPIRE");
-                        args.Add(ttl.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                        args.Add(ttl.Value.TotalMillisecondsString());
                     }
 
                     await _connection.CreateAndEvalAsync(scriptName, new[] { key }, args.ToArray());
                 }
                 else if (ttl is not null)
                 {
-                    await _connection.ExecuteAsync("PEXPIRE", key, ttl.Value.TotalMilliseconds);
+                    await _connection.ExecuteAsync("PEXPIRE", key, ttl.Value.TotalMillisecondsString());
                 }
             }
             else
@@ -841,14 +841,14 @@ namespace Redis.OM.Searching
                     if (ttl is not null)
                     {
                         args.Add("EXPIRE");
-                        args.Add(ttl.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                        args.Add(ttl.Value.TotalMillisecondsString());
                     }
 
                     _connection.CreateAndEval(scriptName, new[] { key }, args.ToArray());
                 }
                 else if (ttl is not null)
                 {
-                    _connection.Execute("PEXPIRE", key, ttl.Value.TotalMilliseconds);
+                    _connection.Execute("PEXPIRE", key, ttl.Value.TotalMillisecondsString());
                 }
             }
             else
@@ -879,14 +879,14 @@ namespace Redis.OM.Searching
                     if (ttl is not null)
                     {
                         args.Add("EXPIRE");
-                        args.Add(ttl.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                        args.Add(ttl.Value.TotalMillisecondsString());
                     }
 
                     task = _connection.CreateAndEvalAsync(scriptName, new[] { key }, args.ToArray());
                 }
                 else if (ttl is not null)
                 {
-                    task = _connection.ExecuteAsync("PEXPIRE", key, ttl.Value.TotalMilliseconds);
+                    task = _connection.ExecuteAsync("PEXPIRE", key, ttl.Value.TotalMillisecondsString());
                 }
             }
             else

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -65,7 +65,7 @@ namespace Redis.OM.Unit.Tests
             var jsonObjWithExpire = new BasicJsonObject { Name = "JsonWithExpire" };
             var key = await connection.SetAsync(jsonObjWithExpire, TimeSpan.FromMilliseconds(5000.5));
             var ttl = (long)await connection.ExecuteAsync("PTTL", key);
-            Assert.True(ttl <= 5000.5);
+            Assert.True(ttl <= 5001);
             Assert.True(ttl >= 1000);
         }
 

--- a/test/Redis.OM.Unit.Tests/CoreTests.cs
+++ b/test/Redis.OM.Unit.Tests/CoreTests.cs
@@ -78,7 +78,7 @@ namespace Redis.OM.Unit.Tests
             var jsonObjWithExpire = new BasicJsonObject { Name = "JsonWithExpire" };
             var key = connection.Set(jsonObjWithExpire, TimeSpan.FromMilliseconds(5000.5));
             var ttl = (long)connection.Execute("PTTL", key);
-            Assert.True(ttl <= 5000.5);
+            Assert.True(ttl <= 5001);
             Assert.True(ttl >= 1000);
         }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -477,7 +477,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             var secondQueriedP = await collection.FindByIdAsync(key);
 
             Assert.Equal("3600001", ttl.TotalMillisecondsString());
-            Assert.InRange(ttlFromKey, ttl.TotalMilliseconds - 2000, ttl.TotalMilliseconds);
+            Assert.InRange(ttlFromKey, ttl.TotalMilliseconds - 2000, ttl.TotalMilliseconds + 1);
             Assert.NotNull(secondQueriedP);
             Assert.Equal(33, secondQueriedP.Age);
             Assert.Equal(secondQueriedP.Id, queriedP.Id);

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -457,6 +457,32 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(secondQueriedP.Id, queriedP.Id);
             Assert.Equal(testP.Id, secondQueriedP.Id);
         }
+        
+        [Fact]
+        public async Task TestUpdateWithTtlAsyncFractionalTimespan()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var testP = new Person { Name = "Steve", Age = 32 };
+            var key = await collection.InsertAsync(testP);
+            var queriedP = await collection.FindByIdAsync(key);
+            Assert.NotNull(queriedP);
+            queriedP.Age = 33;
+            TimeSpan ttl = TimeSpan.FromHours(1);
+            ttl = ttl.Add(TimeSpan.FromTicks(5000));
+            
+            await collection.UpdateAsync(queriedP, ttl);
+
+            var ttlFromKey = (double) await _connection.ExecuteAsync("PTTL", key);
+
+            var secondQueriedP = await collection.FindByIdAsync(key);
+
+            Assert.Equal("3600001", ttl.TotalMillisecondsString());
+            Assert.InRange(ttlFromKey, ttl.TotalMilliseconds - 2000, ttl.TotalMilliseconds);
+            Assert.NotNull(secondQueriedP);
+            Assert.Equal(33, secondQueriedP.Age);
+            Assert.Equal(secondQueriedP.Id, queriedP.Id);
+            Assert.Equal(testP.Id, secondQueriedP.Id);
+        }
 
         [Fact]
         public async Task TestUpdateName()


### PR DESCRIPTION
Fixes issues with timespans having fractional milliseconds values. Came up in a response to #430. Timespans have a TotalMilliseconds which is a double and was not properly rounded when it was fractional.