### PR TITLE
FIELDENG-681 adding api for running raw queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,44 @@ customers.Where(x => x.LastName == "Bond" && x.FirstName == "James");
 customers.Where(x=>x.NickNames.Contains("Jim"));
 ```
 
+#### Using Raw Queries
+
+For advanced scenarios where you need direct control over the filter syntax, Redis OM provides a Raw extension method that lets you write the query filter using the Redis Search query syntax directly:
+
+```csharp
+// Use raw query to find customers named Bond with exact tag matching
+var results = customers.Raw("@LastName:{Bond}").ToList();
+```
+
+**Important**: The Raw method ONLY sets the filter portion of the query. For all other query parameters such as sorting, pagination, etc., you should continue to use the LINQ methods:
+
+```csharp
+// Raw for filter + OrderBy for sorting
+var results = customers.Raw("@LastName:{Bond}")
+    .OrderBy(c => c.Age)
+    .ToList();
+
+// Raw for filter + Skip/Take for pagination
+var results = customers.Raw("@Age:[30 70]")
+    .Skip(10)
+    .Take(5)
+    .ToList();
+```
+
+This is also true for aggregations, where Raw only sets the initial filter, and you should use the full aggregation API for the rest of the pipeline:
+
+```csharp
+var aggSet = customers.AggregationSet();
+
+// Raw sets ONLY the filter, then use the aggregation API for operations
+var results = aggSet.Raw("@Age:[30 70]")
+    .GroupBy(x => x.RecordShell.LastName)
+    .Average(x => x.RecordShell.Age)
+    .ToList();
+```
+
+For more details on the Redis Search query syntax for filters, refer to the [RediSearch Query Syntax Documentation](https://redis.io/docs/stack/search/reference/query_syntax/).
+
 ### Vectors
 
 Redis OM .NET also supports storing and querying Vectors stored in Redis. 

--- a/examples/Redis.OM.RawQueryExample/Program.cs
+++ b/examples/Redis.OM.RawQueryExample/Program.cs
@@ -1,0 +1,94 @@
+using Redis.OM;
+using Redis.OM.Modeling;
+using Redis.OM.Searching;
+using System;
+
+namespace Redis.OM.RawQueryExample
+{
+    [Document(StorageType = StorageType.Json, IndexName = "person-idx")]
+    public class Person
+    {
+        [RedisIdField]
+        [Indexed]
+        public string Id { get; set; } = Ulid.NewUlid().ToString();
+
+        [Indexed]
+        public string FirstName { get; set; }
+
+        [Indexed]
+        public string LastName { get; set; }
+
+        [Searchable]
+        public string FullText { get; set; }
+        
+        [Indexed(Sortable = true)]
+        public int Age { get; set; }
+
+        [Indexed]
+        public string[] Skills { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var provider = new RedisConnectionProvider("redis://localhost:6379");
+            var connection = provider.Connection;
+
+            // Create index if it doesn't exist
+            connection.CreateIndex(typeof(Person));
+
+            // Add some sample data
+            var collection = provider.RedisCollection<Person>();
+            
+            if (!collection.Any())
+            {
+                collection.Insert(new Person { FirstName = "John", LastName = "Doe", Age = 30, Skills = new[] { "C#", "Redis" }, FullText = "Hey Now Brown Cow"});
+                collection.Insert(new Person { FirstName = "Jane", LastName = "Smith", Age = 28, Skills = new[] { "Java", "MongoDB", "Redis" } });
+                collection.Insert(new Person { FirstName = "Bob", LastName = "Johnson", Age = 35, Skills = new[] { "Python", "Redis", "AWS" } });
+                collection.Insert(new Person { FirstName = "Alice", LastName = "Williams", Age = 32, Skills = new[] { "JavaScript", "Node.js" } });
+            }
+
+            Console.WriteLine("=== Using standard LINQ expression ===");
+            var linqResult = collection.Where(p => p.Age > 30).ToList();
+            PrintResults(linqResult);
+
+            Console.WriteLine("\n=== Using Raw query expression ===");
+            var rawResult = collection.Raw("@Age:[31 +inf]").ToList();
+            PrintResults(rawResult);
+
+            Console.WriteLine("\n=== Using Raw query for tag search ===");
+            var skillsResult = collection.Raw("@Skills:{Redis}").ToList();
+            PrintResults(skillsResult);
+
+            Console.WriteLine("\n=== Using Raw query with complex conditions ===");
+            var complexResult = collection.Raw("@Age:[30 35] @Skills:{Redis}").ToList();
+            PrintResults(complexResult);
+
+            // Using Raw with AggregationSet properly
+            Console.WriteLine("\n=== Using Raw with AggregationSet ===");
+            
+            // The proper way - Raw only sets the filter part, then use regular aggregation API
+            var aggSet = provider.AggregationSet<Person>();
+            var aggregationResult = aggSet.Raw("*")
+                .GroupBy(x => x.RecordShell.Skills)
+                .CountGroupMembers()
+                .ToList();
+            
+            Console.WriteLine("Skills grouped by count:");
+            foreach (var result in aggregationResult)
+            {
+                Console.WriteLine($"Skill: {result["Skills"]}, Count: {result["COUNT"]}");
+            }
+        }
+
+        static void PrintResults(System.Collections.Generic.IEnumerable<Person> results)
+        {
+            foreach (var person in results)
+            {
+                Console.WriteLine($"{person.FirstName} {person.LastName}, Age: {person.Age}, Skills: {string.Join(", ", person.Skills)}");
+            }
+            Console.WriteLine($"Total results: {results.Count()}");
+        }
+    }
+}

--- a/examples/Redis.OM.RawQueryExample/Redis.OM.RawQueryExample.csproj
+++ b/examples/Redis.OM.RawQueryExample/Redis.OM.RawQueryExample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Redis.OM\Redis.OM.csproj" />
+    <PackageReference Include="Ulid" Version="1.2.6" />
+  </ItemGroup>
+
+</Project>

--- a/src/Redis.OM/Aggregation/RedisAggregation.cs
+++ b/src/Redis.OM/Aggregation/RedisAggregation.cs
@@ -44,6 +44,11 @@ namespace Redis.OM.Aggregation
         public Stack<IAggregationPredicate> Predicates { get; } = new ();
 
         /// <summary>
+        /// Gets or sets the raw query string for direct execution.
+        /// </summary>
+        public string? RawQuery { get; set; }
+
+        /// <summary>
         /// serializes the aggregation into an array of arguments for redis.
         /// </summary>
         /// <returns>The serialized arguments.</returns>
@@ -51,7 +56,11 @@ namespace Redis.OM.Aggregation
         {
             var queries = new List<string>();
             var ret = new List<string>() { IndexName };
-            if (Queries.Any())
+            if (!string.IsNullOrEmpty(RawQuery))
+            {
+                ret.Add(RawQuery!);
+            }
+            else if (Queries.Any())
             {
                 foreach (var query in Queries)
                 {

--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -161,6 +161,10 @@ namespace Redis.OM.Common
                     case "LoadAll":
                         aggregation.Predicates.Push(new LoadAll());
                         break;
+                    case "Raw":
+                        var rawQuery = ((ConstantExpression)exp.Arguments[1]).Value.ToString();
+                        aggregation.RawQuery = rawQuery;
+                        break;
                 }
             }
 
@@ -235,6 +239,9 @@ namespace Redis.OM.Common
                                 break;
                             case "NearestNeighbors":
                                 query.NearestNeighbors = ParseNearestNeighborsFromExpression(exp);
+                                break;
+                            case "Raw":
+                                query.QueryText = ((ConstantExpression)exp.Arguments[1]).Value.ToString();
                                 break;
                         }
                     }

--- a/src/Redis.OM/SearchExtensions.cs
+++ b/src/Redis.OM/SearchExtensions.cs
@@ -15,6 +15,40 @@ namespace Redis.OM
     public static class SearchExtensions
     {
         /// <summary>
+        /// Executes a raw search query string directly against Redis.
+        /// </summary>
+        /// <param name="source">The source collection.</param>
+        /// <param name="rawQuery">Raw query string to be used directly in Redis search.</param>
+        /// <typeparam name="T">The indexed type.</typeparam>
+        /// <returns>A Redis Collection with the raw query expression applied.</returns>
+        public static IRedisCollection<T> Raw<T>(this IRedisCollection<T> source, string rawQuery)
+            where T : notnull
+        {
+            var collection = (RedisCollection<T>)source;
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(Raw, source, rawQuery),
+                new[] { source.Expression, Expression.Constant(rawQuery) });
+            return new RedisCollection<T>((RedisQueryProvider)source.Provider, exp, source.StateManager, collection.BooleanExpression, source.SaveState, source.ChunkSize);
+        }
+
+        /// <summary>
+        /// Executes a raw aggregation query string directly against Redis.
+        /// </summary>
+        /// <param name="source">The source aggregation set.</param>
+        /// <param name="rawQuery">Raw query string to be used directly in Redis aggregation.</param>
+        /// <typeparam name="T">The indexed type.</typeparam>
+        /// <returns>A Redis AggregationSet with the raw query expression applied.</returns>
+        public static RedisAggregationSet<T> Raw<T>(this RedisAggregationSet<T> source, string rawQuery)
+        {
+            var exp = Expression.Call(
+                null,
+                GetMethodInfo(Raw, source, rawQuery),
+                new[] { source.Expression, Expression.Constant(rawQuery) });
+            return new RedisAggregationSet<T>(source, exp);
+        }
+
+        /// <summary>
         /// Apply the provided expression to data in Redis.
         /// </summary>
         /// <param name="source">The Aggregation set.</param>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
@@ -186,7 +186,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Received().Execute(
                 "FT.SEARCH",
                 "person-idx",
-                "(@Age:[30 40] (@Name:\"Steve\"))",
+                "((@Name:\"Steve\") @Age:[30 40])",
                 "LIMIT",
                 "0",
                 "100");
@@ -242,7 +242,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             var aggSet = new RedisAggregationSet<Person>(_substitute);
             // Raw should only set the query part (@Age:[30 +inf])
-            var result = aggSet.Raw("@Age:[30 +inf]")
+            var result = aggSet.Raw("@Age:[30 inf]")
                 .GroupBy(x => x.RecordShell.DepartmentNumber)
                 .Average(x => x.RecordShell.Age)
                 .ToList();
@@ -250,11 +250,14 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Received().Execute(
                 Arg.Is<string>(s => s == "FT.AGGREGATE"),
                 Arg.Is<string>(s => s == "person-idx"),
-                Arg.Is<string>(s => s == "@Age:[30 +inf]"),
+                Arg.Is<string>(s => s == "@Age:[30 inf]"),
                 Arg.Any<string>(),
                 Arg.Any<object>(),
                 Arg.Any<object>(),
                 Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>(),
+                Arg.Any<object>(),
                 Arg.Any<object>(),
                 Arg.Any<object>());
 
@@ -310,6 +313,8 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 Arg.Any<object>(),
                 Arg.Any<object>(),
                 Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>(),
                 Arg.Any<object>(),
                 Arg.Any<object>());
         }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using Redis.OM.Aggregation;
+using Redis.OM.Contracts;
+using Redis.OM.Searching;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    public class RawQueryTests
+    {
+        // private readonly IRedisConnection _substitute = Substitute.For<IRedisConnection>();
+        // private readonly RedisReply _mockReply = new RedisReply[]
+        // {
+        //     new(1),
+        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
+        //     new(new RedisReply[]
+        //     {
+        //         "$",
+        //         "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
+        //     })
+        // };
+        //
+        // private readonly RedisReply _mockReplyMultiple = new RedisReply[]
+        // {
+        //     new(2),
+        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
+        //     new(new RedisReply[]
+        //     {
+        //         "$",
+        //         "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
+        //     }),
+        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY74O"),
+        //     new(new RedisReply[]
+        //     {
+        //         "$",
+        //         "{\"Name\":\"Alice\",\"Age\":28,\"Height\":67.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY74O\"}"
+        //     })
+        // };
+        //
+        // private readonly RedisReply _mockAggregationReply = new RedisReply[]
+        // {
+        //     new(1),
+        //     new RedisReply[]
+        //     {
+        //         new("Age"),
+        //         new("32")
+        //     }
+        // };
+        //
+        // private readonly RedisReply _mockAggregationMultipleReply = new RedisReply[]
+        // {
+        //     new(2),
+        //     new RedisReply[]
+        //     {
+        //         new("DepartmentNumber"),
+        //         new("1"),
+        //         new("avg_age"),
+        //         new("35")
+        //     },
+        //     new RedisReply[]
+        //     {
+        //         new("DepartmentNumber"),
+        //         new("2"),
+        //         new("avg_age"),
+        //         new("55")
+        //     }
+        // };
+        //
+        // [Fact]
+        // public void TestRawQuery_Basic()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("@Name:{Steve}").ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "@Name:{Steve}",
+        //         "LIMIT",
+        //         "0",
+        //         "100");
+        //
+        //     Assert.Single(result);
+        //     Assert.Equal("Steve", result[0].Name);
+        //     Assert.Equal(32, result[0].Age);
+        //     Assert.Equal(71.0, result[0].Height);
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_ComplexCondition()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("@Age:[30 40] @Height:[70 +inf]").ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "@Age:[30 40] @Height:[70 +inf]",
+        //         "LIMIT",
+        //         "0",
+        //         "100");
+        //
+        //     Assert.Single(result);
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_WithLIMITParameters()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("*").Skip(1).Take(1).ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "*",
+        //         "LIMIT",
+        //         "1",
+        //         "1");
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_WithORDERBYParameters()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("*").OrderBy(p => p.Age).ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "*",
+        //         "LIMIT",
+        //         "0",
+        //         "100",
+        //         "SORTBY",
+        //         "Age",
+        //         "ASC");
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_WithORDERBYDescendingParameters()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("*").OrderByDescending(p => p.Age).ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "*",
+        //         "LIMIT",
+        //         "0",
+        //         "100",
+        //         "SORTBY",
+        //         "Age",
+        //         "DESC");
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_WithWhereClauseChaining()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("@Age:[30 40]").Where(p => p.Name == "Steve").ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "(@Age:[30 40] (@Name:\"Steve\"))",
+        //         "LIMIT",
+        //         "0",
+        //         "100");
+        // }
+        //
+        // [Fact]
+        // public void TestRawQuery_FirstOrDefault()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+        //
+        //     var collection = new RedisCollection<Person>(_substitute);
+        //     var result = collection.Raw("@Name:{Steve}").FirstOrDefault();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.SEARCH",
+        //         "person-idx",
+        //         "@Name:{Steve}",
+        //         "LIMIT",
+        //         "0",
+        //         "1");
+        //
+        //     Assert.Equal("Steve", result.Name);
+        // }
+        //
+        // [Fact]
+        // public void TestRawAggregation_BasicQuery()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+        //
+        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
+        //     // Raw should only set the query part (*)
+        //     var result = aggSet.Raw("*").GroupBy(x => x.RecordShell.Age).ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.AGGREGATE",
+        //         "person-idx",
+        //         "*",
+        //         "GROUPBY",
+        //         "1",
+        //         "@Age");
+        //
+        //     Assert.Single(result);
+        //     Assert.Equal("32", result[0]["Age"].ToString());
+        // }
+        //
+        // [Fact]
+        // public void TestRawAggregation_WithCustomFilter()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationMultipleReply);
+        //
+        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
+        //     // Raw should only set the query part (@Age:[30 +inf])
+        //     var result = aggSet.Raw("@Age:[30 +inf]")
+        //         .GroupBy(x => x.RecordShell.DepartmentNumber)
+        //         .Average(x => x.RecordShell.Age)
+        //         .ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         Arg.Is<string>(s => s == "FT.AGGREGATE"),
+        //         Arg.Is<string>(s => s == "person-idx"),
+        //         Arg.Is<string>(s => s == "@Age:[30 +inf]"),
+        //         Arg.Any<string>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<string>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<object>());
+        //
+        //     Assert.Equal(2, result.Count);
+        //     
+        //     var dept1 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "1");
+        //     var dept2 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "2");
+        //     
+        //     Assert.NotNull(dept1);
+        //     Assert.NotNull(dept2);
+        //     Assert.Equal("35", dept1["avg_age"].ToString());
+        //     Assert.Equal("55", dept2["avg_age"].ToString());
+        // }
+        //
+        // [Fact]
+        // public void TestRawAggregation_WithPipelineOperations()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+        //
+        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
+        //     // Raw only sets the filter query part, skip/take still work as expected
+        //     var result = aggSet.Raw("@Age > 30").Skip(0).Take(10).ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         "FT.AGGREGATE",
+        //         "person-idx",
+        //         "@Age > 30",
+        //         "LIMIT",
+        //         "0",
+        //         "10");
+        // }
+        //
+        // [Fact]
+        // public void TestRawAggregation_ComplexFilter()
+        // {
+        //     _substitute.ClearSubstitute();
+        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+        //
+        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
+        //     
+        //     // Use Raw to set a complex filter
+        //     var result = aggSet.Raw("(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]")
+        //         .GroupBy(x => x.RecordShell.DepartmentNumber)
+        //         .CountGroupMembers()
+        //         .ToList();
+        //
+        //     _substitute.Received().Execute(
+        //         Arg.Is<string>(s => s == "FT.AGGREGATE"),
+        //         Arg.Is<string>(s => s == "person-idx"),
+        //         Arg.Is<string>(s => s == "(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]"),
+        //         Arg.Any<string>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<string>(),
+        //         Arg.Any<object>(),
+        //         Arg.Any<object>());
+        // }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RawQueryTests.cs
@@ -13,305 +13,305 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 {
     public class RawQueryTests
     {
-        // private readonly IRedisConnection _substitute = Substitute.For<IRedisConnection>();
-        // private readonly RedisReply _mockReply = new RedisReply[]
-        // {
-        //     new(1),
-        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
-        //     new(new RedisReply[]
-        //     {
-        //         "$",
-        //         "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
-        //     })
-        // };
-        //
-        // private readonly RedisReply _mockReplyMultiple = new RedisReply[]
-        // {
-        //     new(2),
-        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
-        //     new(new RedisReply[]
-        //     {
-        //         "$",
-        //         "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
-        //     }),
-        //     new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY74O"),
-        //     new(new RedisReply[]
-        //     {
-        //         "$",
-        //         "{\"Name\":\"Alice\",\"Age\":28,\"Height\":67.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY74O\"}"
-        //     })
-        // };
-        //
-        // private readonly RedisReply _mockAggregationReply = new RedisReply[]
-        // {
-        //     new(1),
-        //     new RedisReply[]
-        //     {
-        //         new("Age"),
-        //         new("32")
-        //     }
-        // };
-        //
-        // private readonly RedisReply _mockAggregationMultipleReply = new RedisReply[]
-        // {
-        //     new(2),
-        //     new RedisReply[]
-        //     {
-        //         new("DepartmentNumber"),
-        //         new("1"),
-        //         new("avg_age"),
-        //         new("35")
-        //     },
-        //     new RedisReply[]
-        //     {
-        //         new("DepartmentNumber"),
-        //         new("2"),
-        //         new("avg_age"),
-        //         new("55")
-        //     }
-        // };
-        //
-        // [Fact]
-        // public void TestRawQuery_Basic()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("@Name:{Steve}").ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "@Name:{Steve}",
-        //         "LIMIT",
-        //         "0",
-        //         "100");
-        //
-        //     Assert.Single(result);
-        //     Assert.Equal("Steve", result[0].Name);
-        //     Assert.Equal(32, result[0].Age);
-        //     Assert.Equal(71.0, result[0].Height);
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_ComplexCondition()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("@Age:[30 40] @Height:[70 +inf]").ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "@Age:[30 40] @Height:[70 +inf]",
-        //         "LIMIT",
-        //         "0",
-        //         "100");
-        //
-        //     Assert.Single(result);
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_WithLIMITParameters()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("*").Skip(1).Take(1).ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "*",
-        //         "LIMIT",
-        //         "1",
-        //         "1");
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_WithORDERBYParameters()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("*").OrderBy(p => p.Age).ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "*",
-        //         "LIMIT",
-        //         "0",
-        //         "100",
-        //         "SORTBY",
-        //         "Age",
-        //         "ASC");
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_WithORDERBYDescendingParameters()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("*").OrderByDescending(p => p.Age).ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "*",
-        //         "LIMIT",
-        //         "0",
-        //         "100",
-        //         "SORTBY",
-        //         "Age",
-        //         "DESC");
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_WithWhereClauseChaining()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("@Age:[30 40]").Where(p => p.Name == "Steve").ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "(@Age:[30 40] (@Name:\"Steve\"))",
-        //         "LIMIT",
-        //         "0",
-        //         "100");
-        // }
-        //
-        // [Fact]
-        // public void TestRawQuery_FirstOrDefault()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
-        //
-        //     var collection = new RedisCollection<Person>(_substitute);
-        //     var result = collection.Raw("@Name:{Steve}").FirstOrDefault();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.SEARCH",
-        //         "person-idx",
-        //         "@Name:{Steve}",
-        //         "LIMIT",
-        //         "0",
-        //         "1");
-        //
-        //     Assert.Equal("Steve", result.Name);
-        // }
-        //
-        // [Fact]
-        // public void TestRawAggregation_BasicQuery()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
-        //
-        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
-        //     // Raw should only set the query part (*)
-        //     var result = aggSet.Raw("*").GroupBy(x => x.RecordShell.Age).ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.AGGREGATE",
-        //         "person-idx",
-        //         "*",
-        //         "GROUPBY",
-        //         "1",
-        //         "@Age");
-        //
-        //     Assert.Single(result);
-        //     Assert.Equal("32", result[0]["Age"].ToString());
-        // }
-        //
-        // [Fact]
-        // public void TestRawAggregation_WithCustomFilter()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationMultipleReply);
-        //
-        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
-        //     // Raw should only set the query part (@Age:[30 +inf])
-        //     var result = aggSet.Raw("@Age:[30 +inf]")
-        //         .GroupBy(x => x.RecordShell.DepartmentNumber)
-        //         .Average(x => x.RecordShell.Age)
-        //         .ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         Arg.Is<string>(s => s == "FT.AGGREGATE"),
-        //         Arg.Is<string>(s => s == "person-idx"),
-        //         Arg.Is<string>(s => s == "@Age:[30 +inf]"),
-        //         Arg.Any<string>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<string>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<object>());
-        //
-        //     Assert.Equal(2, result.Count);
-        //     
-        //     var dept1 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "1");
-        //     var dept2 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "2");
-        //     
-        //     Assert.NotNull(dept1);
-        //     Assert.NotNull(dept2);
-        //     Assert.Equal("35", dept1["avg_age"].ToString());
-        //     Assert.Equal("55", dept2["avg_age"].ToString());
-        // }
-        //
-        // [Fact]
-        // public void TestRawAggregation_WithPipelineOperations()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
-        //
-        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
-        //     // Raw only sets the filter query part, skip/take still work as expected
-        //     var result = aggSet.Raw("@Age > 30").Skip(0).Take(10).ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         "FT.AGGREGATE",
-        //         "person-idx",
-        //         "@Age > 30",
-        //         "LIMIT",
-        //         "0",
-        //         "10");
-        // }
-        //
-        // [Fact]
-        // public void TestRawAggregation_ComplexFilter()
-        // {
-        //     _substitute.ClearSubstitute();
-        //     _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
-        //
-        //     var aggSet = new RedisAggregationSet<Person>(_substitute);
-        //     
-        //     // Use Raw to set a complex filter
-        //     var result = aggSet.Raw("(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]")
-        //         .GroupBy(x => x.RecordShell.DepartmentNumber)
-        //         .CountGroupMembers()
-        //         .ToList();
-        //
-        //     _substitute.Received().Execute(
-        //         Arg.Is<string>(s => s == "FT.AGGREGATE"),
-        //         Arg.Is<string>(s => s == "person-idx"),
-        //         Arg.Is<string>(s => s == "(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]"),
-        //         Arg.Any<string>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<string>(),
-        //         Arg.Any<object>(),
-        //         Arg.Any<object>());
-        // }
+        private readonly IRedisConnection _substitute = Substitute.For<IRedisConnection>();
+        private readonly RedisReply _mockReply = new RedisReply[]
+        {
+            new(1),
+            new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
+            new(new RedisReply[]
+            {
+                "$",
+                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
+            })
+        };
+
+        private readonly RedisReply _mockReplyMultiple = new RedisReply[]
+        {
+            new(2),
+            new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY73N"),
+            new(new RedisReply[]
+            {
+                "$",
+                "{\"Name\":\"Steve\",\"Age\":32,\"Height\":71.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY73N\"}"
+            }),
+            new("Redis.OM.Unit.Tests.RediSearchTests.Person:01FVN836BNQGYMT80V7RCVY74O"),
+            new(new RedisReply[]
+            {
+                "$",
+                "{\"Name\":\"Alice\",\"Age\":28,\"Height\":67.0, \"Id\":\"01FVN836BNQGYMT80V7RCVY74O\"}"
+            })
+        };
+
+        private readonly RedisReply _mockAggregationReply = new RedisReply[]
+        {
+            new(1),
+            new RedisReply[]
+            {
+                new("Age"),
+                new("32")
+            }
+        };
+
+        private readonly RedisReply _mockAggregationMultipleReply = new RedisReply[]
+        {
+            new(2),
+            new RedisReply[]
+            {
+                new("DepartmentNumber"),
+                new("1"),
+                new("avg_age"),
+                new("35")
+            },
+            new RedisReply[]
+            {
+                new("DepartmentNumber"),
+                new("2"),
+                new("avg_age"),
+                new("55")
+            }
+        };
+
+        [Fact]
+        public void TestRawQuery_Basic()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("@Name:{Steve}").ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "@Name:{Steve}",
+                "LIMIT",
+                "0",
+                "100");
+
+            Assert.Single(result);
+            Assert.Equal("Steve", result[0].Name);
+            Assert.Equal(32, result[0].Age);
+            Assert.Equal(71.0, result[0].Height);
+        }
+
+        [Fact]
+        public void TestRawQuery_ComplexCondition()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("@Age:[30 40] @Height:[70 +inf]").ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "@Age:[30 40] @Height:[70 +inf]",
+                "LIMIT",
+                "0",
+                "100");
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void TestRawQuery_WithLIMITParameters()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("*").Skip(1).Take(1).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "*",
+                "LIMIT",
+                "1",
+                "1");
+        }
+
+        [Fact]
+        public void TestRawQuery_WithORDERBYParameters()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("*").OrderBy(p => p.Age).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "*",
+                "LIMIT",
+                "0",
+                "100",
+                "SORTBY",
+                "Age",
+                "ASC");
+        }
+
+        [Fact]
+        public void TestRawQuery_WithORDERBYDescendingParameters()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReplyMultiple);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("*").OrderByDescending(p => p.Age).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "*",
+                "LIMIT",
+                "0",
+                "100",
+                "SORTBY",
+                "Age",
+                "DESC");
+        }
+
+        [Fact]
+        public void TestRawQuery_WithWhereClauseChaining()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("@Age:[30 40]").Where(p => p.Name == "Steve").ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Age:[30 40] (@Name:\"Steve\"))",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestRawQuery_FirstOrDefault()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var result = collection.Raw("@Name:{Steve}").FirstOrDefault();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "@Name:{Steve}",
+                "LIMIT",
+                "0",
+                "1");
+
+            Assert.Equal("Steve", result.Name);
+        }
+
+        [Fact]
+        public void TestRawAggregation_BasicQuery()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+
+            var aggSet = new RedisAggregationSet<Person>(_substitute);
+            // Raw should only set the query part (*)
+            var result = aggSet.Raw("*").GroupBy(x => x.RecordShell.Age).ToList();
+
+            _substitute.Received().Execute(
+                "FT.AGGREGATE",
+                "person-idx",
+                "*",
+                "GROUPBY",
+                "1",
+                "@Age");
+
+            Assert.Single(result);
+            Assert.Equal("32", result[0]["Age"].ToString());
+        }
+
+        [Fact]
+        public void TestRawAggregation_WithCustomFilter()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationMultipleReply);
+
+            var aggSet = new RedisAggregationSet<Person>(_substitute);
+            // Raw should only set the query part (@Age:[30 +inf])
+            var result = aggSet.Raw("@Age:[30 +inf]")
+                .GroupBy(x => x.RecordShell.DepartmentNumber)
+                .Average(x => x.RecordShell.Age)
+                .ToList();
+
+            _substitute.Received().Execute(
+                Arg.Is<string>(s => s == "FT.AGGREGATE"),
+                Arg.Is<string>(s => s == "person-idx"),
+                Arg.Is<string>(s => s == "@Age:[30 +inf]"),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>());
+
+            Assert.Equal(2, result.Count);
+            
+            var dept1 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "1");
+            var dept2 = result.FirstOrDefault(r => r["DepartmentNumber"].ToString() == "2");
+            
+            Assert.NotNull(dept1);
+            Assert.NotNull(dept2);
+            Assert.Equal("35", dept1["avg_age"].ToString());
+            Assert.Equal("55", dept2["avg_age"].ToString());
+        }
+
+        [Fact]
+        public void TestRawAggregation_WithPipelineOperations()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+
+            var aggSet = new RedisAggregationSet<Person>(_substitute);
+            // Raw only sets the filter query part, skip/take still work as expected
+            var result = aggSet.Raw("@Age > 30").Skip(0).Take(10).ToList();
+
+            _substitute.Received().Execute(
+                "FT.AGGREGATE",
+                "person-idx",
+                "@Age > 30",
+                "LIMIT",
+                "0",
+                "10");
+        }
+        
+        [Fact]
+        public void TestRawAggregation_ComplexFilter()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockAggregationReply);
+
+            var aggSet = new RedisAggregationSet<Person>(_substitute);
+            
+            // Use Raw to set a complex filter
+            var result = aggSet.Raw("(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]")
+                .GroupBy(x => x.RecordShell.DepartmentNumber)
+                .CountGroupMembers()
+                .ToList();
+
+            _substitute.Received().Execute(
+                Arg.Is<string>(s => s == "FT.AGGREGATE"),
+                Arg.Is<string>(s => s == "person-idx"),
+                Arg.Is<string>(s => s == "(@Age:[30 40] | @Name:Steve) @Height:[70 +inf]"),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<object>());
+        }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -1374,5 +1374,53 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.NotNull(updated.Guid);
             Assert.True(updated.Bool);
         }
+        
+        [Fact]
+        public void TestRawQuery()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var person = new Person { Name = "RawQueryTest", Age = 42, Sales = 500000};
+            collection.Insert(person);
+            
+            // Test basic raw query
+            var result1 = collection.Raw("RawQueryTest").ToList();
+            Assert.Single(result1);
+            Assert.Equal("RawQueryTest", result1[0].Name);
+            Assert.Equal(42, result1[0].Age);
+            
+            // Test raw query with numeric range
+            var result2 = collection.Raw("@Age:[40 45]").Where(p => p.Name == "RawQueryTest").ToList();
+            Assert.Single(result2);
+            Assert.Equal("RawQueryTest", result2[0].Name);
+            
+            // Test raw query with OR condition
+            var result3 = collection.Raw("@Age:[40 45] | @Name:Steve").ToList();
+            Assert.Contains(result3, p => p.Name == "RawQueryTest");
+            
+            // Test raw query with multiple conditions
+            var result4 = collection.Raw("@Age:[40 45] @Name:RawQueryTest").ToList();
+            Assert.Single(result4);
+            Assert.Equal("RawQueryTest", result4[0].Name);
+            
+            // Cleanup
+            collection.Delete(person);
+        }
+        
+        [Fact]
+        public async Task TestRawQueryAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var person = new Person { Name = "AsyncRawQueryTest", Age = 33, Sales = 50000};
+            await collection.InsertAsync(person);
+            
+            // Test basic raw query async
+            var result = await collection.Raw("AsyncRawQueryTest").ToListAsync();
+            Assert.Single(result);
+            Assert.Equal("AsyncRawQueryTest", result[0].Name);
+            Assert.Equal(33, result[0].Age);
+            
+            // Cleanup
+            await collection.DeleteAsync(person);
+        }
     }
 }


### PR DESCRIPTION
We've had many instances where folks have asked for Redis Queries that are difficult (or impossible) to express in the LINQ language, this PR adds support for writing raw filters in the Redis Query Language, while still supporting the Object Mapping / other LINQ bits of Redis OM.