### PR TITLE
Support 'MatchContains' and 'MatchPattern' of string and IEnumerable<string>

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -836,14 +836,26 @@ namespace Redis.OM.Common
         {
             var source = GetOperandString(exp.Arguments[0]);
             var infix = GetOperandString(exp.Arguments[1]);
-            return $"({source}:*{infix}*)";
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:*{infix}*)";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{*{infix}*}})";
         }
 
         private static string TranslateMatchPattern(MethodCallExpression exp)
         {
             var source = GetOperandString(exp.Arguments[0]);
             var pattern = GetOperandString(exp.Arguments[1]);
-            return $"({source}:{pattern})";
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:{pattern})";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{{pattern}}})";
         }
 
         private static string TranslateFuzzyMatch(MethodCallExpression exp)

--- a/src/Redis.OM/Extensions/StringExtension.cs
+++ b/src/Redis.OM/Extensions/StringExtension.cs
@@ -99,6 +99,34 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Checks the source string to see if any tokens within the source contains the infix.
+        /// </summary>
+        /// <param name="source">The string to check.</param>
+        /// <param name="infix">The infix to look for within the string.</param>
+        /// <returns>Whether any token within the source string contains the infix.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchContains(this IEnumerable<string> source, string infix)
+        {
+            var terms = string.Join(" ", source).Split(SplitChars);
+            return terms.Any(t => t.Contains(infix));
+        }
+
+        /// <summary>
+        /// Checks the source string to see if any tokens within the source matches the pattern.
+        /// </summary>
+        /// <param name="source">The string to check.</param>
+        /// <param name="pattern">The pattern to look for within the string.</param>
+        /// <returns>Whether any token within the source string matches the pattern.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchPattern(this IEnumerable<string> source, string pattern)
+        {
+            var terms = string.Join(" ", source).Split(SplitChars);
+            return terms.Any(t => t.EndsWith(pattern));
+        }
+
+        /// <summary>
         /// Wagner-Fischer dynamic programming string distance algorithm.
         /// </summary>
         /// <param name="source">The source string to check the distance from.</param>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -463,7 +463,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestMatchContains()
+        public void TestMatchContainsOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -478,7 +478,24 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "0",
                 "100");
         }
-        
+
+        [Fact]
+        public void TestMatchContainsOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchContains("Ste")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{*Ste*})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
         [Fact]
         public void TestMultipleMatches()
         {
@@ -497,7 +514,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestMatchPattern()
+        public void TestMatchPatternOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -509,6 +526,24 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "FT.SEARCH",
                 "person-idx",
                 "(@Name:Ste* Lo*)",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchPatternOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var ddfgdf = collection.Where(x => x.NickNames.MatchPattern("Ste* Lo*")).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{Ste* Lo*})",
                 "LIMIT",
                 "0",
                 "100");


### PR DESCRIPTION
We can search in `string` by __Full-string__ and __Sub-string__.
But there is now way to search in string[] by __Sub-string__.

I have developed two methods `MatchContains` and `MatchPattern` to solve this problem.