### PR TITLE
Support 'Match...' of string and IEnumerable<string>

### DIFF
--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -822,28 +822,54 @@ namespace Redis.OM.Common
         {
             var source = GetOperandString(exp.Arguments[0]);
             var prefix = GetOperandString(exp.Arguments[1]);
-            return $"({source}:{prefix}*)";
+
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:{prefix}*)";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{{prefix}*}})";
         }
 
         private static string TranslateMatchEndsWith(MethodCallExpression exp)
         {
             var source = GetOperandString(exp.Arguments[0]);
             var suffix = GetOperandString(exp.Arguments[1]);
-            return $"({source}:*{suffix})";
+
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:*{suffix})";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{*{suffix}}})";
         }
 
         private static string TranslateMatchContains(MethodCallExpression exp)
         {
             var source = GetOperandString(exp.Arguments[0]);
             var infix = GetOperandString(exp.Arguments[1]);
-            return $"({source}:*{infix}*)";
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:*{infix}*)";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{*{infix}*}})";
         }
 
         private static string TranslateMatchPattern(MethodCallExpression exp)
         {
             var source = GetOperandString(exp.Arguments[0]);
             var pattern = GetOperandString(exp.Arguments[1]);
-            return $"({source}:{pattern})";
+            if (exp.Arguments[0].Type == typeof(string))
+            {
+                return $"({source}:{pattern})";
+            }
+
+            // IEnumerable<string>
+            return $"({source}:{{{pattern}}})";
         }
 
         private static string TranslateFuzzyMatch(MethodCallExpression exp)

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -828,8 +828,8 @@ namespace Redis.OM.Common
                 return $"({source}:{prefix}*)";
             }
 
-            // IEnumerable<string>
-            return $"({source}:{{{prefix}*}})";
+            // IEnumerable<string> (tag field): escape the literal but keep the trailing wildcard.
+            return $"({source}:{{{EscapeTagField(prefix)}*}})";
         }
 
         private static string TranslateMatchEndsWith(MethodCallExpression exp)
@@ -842,8 +842,8 @@ namespace Redis.OM.Common
                 return $"({source}:*{suffix})";
             }
 
-            // IEnumerable<string>
-            return $"({source}:{{*{suffix}}})";
+            // IEnumerable<string> (tag field): escape the literal but keep the leading wildcard.
+            return $"({source}:{{*{EscapeTagField(suffix)}}})";
         }
 
         private static string TranslateMatchContains(MethodCallExpression exp)
@@ -855,8 +855,8 @@ namespace Redis.OM.Common
                 return $"({source}:*{infix}*)";
             }
 
-            // IEnumerable<string>
-            return $"({source}:{{*{infix}*}})";
+            // IEnumerable<string> (tag field): escape the literal but keep the surrounding wildcards.
+            return $"({source}:{{*{EscapeTagField(infix)}*}})";
         }
 
         private static string TranslateMatchPattern(MethodCallExpression exp)

--- a/src/Redis.OM/Extensions/StringExtension.cs
+++ b/src/Redis.OM/Extensions/StringExtension.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Redis.OM
 {
@@ -81,7 +81,7 @@ namespace Redis.OM
         public static bool MatchContains(this string source, string infix)
         {
             var terms = source.Split(SplitChars);
-            return terms.Any(t => t.EndsWith(infix));
+            return terms.Any(t => t.Contains(infix));
         }
 
         /// <summary>
@@ -94,8 +94,139 @@ namespace Redis.OM
         /// provided here for completeness.</remarks>
         public static bool MatchPattern(this string source, string pattern)
         {
+            var regex = new Regex(WildcardToRegex(pattern));
             var terms = source.Split(SplitChars);
-            return terms.Any(t => t.EndsWith(pattern));
+            return terms.Any(t => regex.IsMatch(t));
+        }
+
+        /// <summary>
+        /// Checks the source array string to see if any tokens within the source string start with the prefix.
+        /// </summary>
+        /// <param name="source">The array string to check.</param>
+        /// <param name="prefix">The prefix to look for within the each string in array.</param>
+        /// <returns>Whether any token within the source string starts with the prefix.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchStartsWith(this IEnumerable<string> source, string prefix)
+        {
+            foreach (var str in source)
+            {
+                var terms = str.Split(SplitChars);
+                return terms.Any(t => t.StartsWith(prefix));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks the source array string to see if any tokens within the source string ends with the suffix.
+        /// </summary>
+        /// <param name="source">The array string to check.</param>
+        /// <param name="suffix">The suffix to look for within the each string in array.</param>
+        /// <returns>Whether any token within the source string ends with the suffix.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchEndsWith(this IEnumerable<string> source, string suffix)
+        {
+            foreach (var str in source)
+            {
+                var terms = str.Split(SplitChars);
+                return terms.Any(t => t.EndsWith(suffix));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks the source array string to see if any tokens within the source contains the infix.
+        /// </summary>
+        /// <param name="source">The array string to check.</param>
+        /// <param name="infix">The infix to look for within the each string in array.</param>
+        /// <returns>Whether any token within the source string contains the infix.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchContains(this IEnumerable<string> source, string infix)
+        {
+            foreach (var str in source)
+            {
+                var terms = str.Split(SplitChars);
+                return terms.Any(t => t.Contains(infix));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks the source array string to see if any tokens within the source matches the pattern.
+        /// </summary>
+        /// <param name="source">The array string to check.</param>
+        /// <param name="pattern">The pattern to look for within the each string in array.</param>
+        /// <returns>Whether any token within the source string matches the pattern.</returns>
+        /// <remarks>This is meant to be a shadow method that runs within an expression, a working implementation is
+        /// provided here for completeness.</remarks>
+        public static bool MatchPattern(this IEnumerable<string> source, string pattern)
+        {
+            var regex = new Regex(WildcardToRegex(pattern));
+            foreach (var str in source)
+            {
+                var terms = str.Split(SplitChars);
+                return terms.Any(t => regex.IsMatch(t));
+            }
+
+            return false;
+        }
+
+        /*
+         * See: https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/query_syntax/#wildcard-matching
+                ? - for any single character
+                * - for any character repeating zero or more times
+                \ - for escaping; other special characters are ignored
+        */
+
+        /// <summary>
+        /// Converts a wildcard pattern to a regex pattern.
+        /// </summary>
+        /// <param name="wildcardPattern">The wildcard pattern like '*foo?bar*'. Use '\' to escape.</param>
+        /// <returns>Return regex pattern and support escaping.</returns>
+        private static string WildcardToRegex(string wildcardPattern)
+        {
+            var regexPattern = new StringBuilder();
+            regexPattern.Append("^");
+
+            int i = 0;
+            while (i < wildcardPattern.Length)
+            {
+                char current = wildcardPattern[i];
+
+                if (current == '\\' && i + 1 < wildcardPattern.Length)
+                {
+                    // Escape the next character
+                    char nextChar = wildcardPattern[i + 1];
+                    regexPattern.Append(Regex.Escape(nextChar.ToString()));
+                    i += 2;
+                }
+                else if (current == '*')
+                {
+                    // Match any character zero or more times
+                    regexPattern.Append(".*");
+                    i++;
+                }
+                else if (current == '?')
+                {
+                    // Match any single character
+                    regexPattern.Append(".");
+                    i++;
+                }
+                else
+                {
+                    // Escape special regex characters
+                    regexPattern.Append(Regex.Escape(current.ToString()));
+                    i++;
+                }
+            }
+
+            regexPattern.Append("$");
+            return regexPattern.ToString();
         }
 
         /// <summary>

--- a/src/Redis.OM/Extensions/StringExtension.cs
+++ b/src/Redis.OM/Extensions/StringExtension.cs
@@ -53,7 +53,7 @@ namespace Redis.OM
         public static bool MatchStartsWith(this string source, string prefix)
         {
             var terms = source.Split(SplitChars);
-            return terms.Any(t => t.StartsWith(prefix));
+            return terms.Any(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Redis.OM
         public static bool MatchEndsWith(this string source, string suffix)
         {
             var terms = source.Split(SplitChars);
-            return terms.Any(t => t.EndsWith(suffix));
+            return terms.Any(t => t.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Redis.OM
         public static bool MatchContains(this string source, string infix)
         {
             var terms = source.Split(SplitChars);
-            return terms.Any(t => t.Contains(infix));
+            return terms.Any(t => t.IndexOf(infix, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Redis.OM
         /// provided here for completeness.</remarks>
         public static bool MatchPattern(this string source, string pattern)
         {
-            var regex = new Regex(WildcardToRegex(pattern));
+            var regex = new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.Compiled);
             var terms = source.Split(SplitChars);
             return terms.Any(t => regex.IsMatch(t));
         }
@@ -112,7 +112,10 @@ namespace Redis.OM
             foreach (var str in source)
             {
                 var terms = str.Split(SplitChars);
-                return terms.Any(t => t.StartsWith(prefix));
+                if (terms.Any(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -131,7 +134,10 @@ namespace Redis.OM
             foreach (var str in source)
             {
                 var terms = str.Split(SplitChars);
-                return terms.Any(t => t.EndsWith(suffix));
+                if (terms.Any(t => t.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -150,7 +156,10 @@ namespace Redis.OM
             foreach (var str in source)
             {
                 var terms = str.Split(SplitChars);
-                return terms.Any(t => t.Contains(infix));
+                if (terms.Any(t => t.IndexOf(infix, StringComparison.OrdinalIgnoreCase) >= 0))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -166,11 +175,14 @@ namespace Redis.OM
         /// provided here for completeness.</remarks>
         public static bool MatchPattern(this IEnumerable<string> source, string pattern)
         {
-            var regex = new Regex(WildcardToRegex(pattern));
+            var regex = new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.Compiled);
             foreach (var str in source)
             {
                 var terms = str.Split(SplitChars);
-                return terms.Any(t => regex.IsMatch(t));
+                if (terms.Any(t => regex.IsMatch(t)))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -1416,145 +1416,167 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(existingRecordsCount, res.Count);
         }
 
-        // Seeds a known pair of people for the Match* functional tests. Clears any existing
-        // people first so the test is independent of ordering, and the caller is expected to
-        // clear again in a finally block so it does not pollute the shared Person collection.
-        private async Task<RedisCollection<Person>> SeedMatchPeopleAsync()
+        // Inserts a known, uniquely-named pair of people for the Match* functional tests. The
+        // names and nicknames are deliberately distinct from the randomly seeded records other
+        // tests create, so the assertions are deterministic without clearing the shared
+        // collection (other tests, e.g. EnumerateAllRecords, depend on those records existing).
+        // The inserted records are returned so each test can delete just those in a finally block.
+        private Person[] InsertMatchPeople(RedisCollection<Person> collection)
         {
-            var collection = new RedisCollection<Person>(_connection);
-            await collection.DeleteAsync(await collection.ToListAsync());
-
-            collection.Insert(new Person { Name = "Steve Lorello", NickNames = new[] { "Steve", "Stevie" } });
-            collection.Insert(new Person { Name = "Harry Potter", NickNames = new[] { "Harry", "Hazza" } });
-
-            return collection;
-        }
-
-        private async Task ClearPeopleAsync()
-        {
-            var collection = new RedisCollection<Person>(_connection);
-            await collection.DeleteAsync(await collection.ToListAsync());
+            var zaphod = new Person { Name = "Zaphod Beeblebrox", NickNames = new[] { "Zaphod", "Zappy" } };
+            var ford = new Person { Name = "Ford Prefect", NickNames = new[] { "Fordo", "Prefect" } };
+            collection.Insert(zaphod);
+            collection.Insert(ford);
+            return new[] { zaphod, ford };
         }
 
         [Fact]
         public async Task TestSearchByMatchStartsWith()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.Name.MatchStartsWith("Ste")).ToListAsync();
+                var res = await collection.Where(x => x.Name.MatchStartsWith("Zaph")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Steve Lorello", res[0].Name);
+                Assert.Equal("Zaphod Beeblebrox", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Fact]
         public async Task TestSearchByMatchEndsWith()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.Name.MatchEndsWith("orello")).ToListAsync();
+                var res = await collection.Where(x => x.Name.MatchEndsWith("brox")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Steve Lorello", res[0].Name);
+                Assert.Equal("Zaphod Beeblebrox", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Fact]
         public async Task TestSearchByMatchContains()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.Name.MatchContains("orell")).ToListAsync();
+                var res = await collection.Where(x => x.Name.MatchContains("eeble")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Steve Lorello", res[0].Name);
+                Assert.Equal("Zaphod Beeblebrox", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Fact]
         public async Task TestSearchByMatchStartsWithStringArray()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.NickNames.MatchStartsWith("Ste")).ToListAsync();
+                var res = await collection.Where(x => x.NickNames.MatchStartsWith("Zap")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Steve Lorello", res[0].Name);
+                Assert.Equal("Zaphod Beeblebrox", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Fact]
         public async Task TestSearchByMatchEndsWithStringArray()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.NickNames.MatchEndsWith("vie")).ToListAsync();
+                var res = await collection.Where(x => x.NickNames.MatchEndsWith("ppy")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Steve Lorello", res[0].Name);
+                Assert.Equal("Zaphod Beeblebrox", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Fact]
         public async Task TestSearchByMatchContainsStringArray()
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
-                var res = await collection.Where(x => x.NickNames.MatchContains("azz")).ToListAsync();
+                var res = await collection.Where(x => x.NickNames.MatchContains("refec")).ToListAsync();
 
                 Assert.Single(res);
-                Assert.Equal("Harry Potter", res[0].Name);
+                Assert.Equal("Ford Prefect", res[0].Name);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
             }
         }
 
         [Theory]
-        [InlineData("Ste*", 1)]
-        [InlineData("*vie", 1)]
-        [InlineData("Ha*", 1)]
+        [InlineData("Zap*", 1)]
+        [InlineData("*ppy", 1)]
+        [InlineData("Ford*", 1)]
         [InlineData("Nope*", 0)]
-        public async Task TestSearchByMatchPatternStringArray(string pattern, int existingRecordsCount)
+        public async Task TestSearchByMatchPatternStringArray(string pattern, int expectedMatchCount)
         {
-            var collection = await SeedMatchPeopleAsync();
+            var collection = new RedisCollection<Person>(_connection);
+            var inserted = InsertMatchPeople(collection);
             try
             {
                 var res = await collection.Where(x => x.NickNames.MatchPattern(pattern)).ToListAsync();
 
-                Assert.Equal(existingRecordsCount, res.Count);
+                Assert.Equal(expectedMatchCount, res.Count);
             }
             finally
             {
-                await ClearPeopleAsync();
+                await collection.DeleteAsync(inserted);
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchTagSpecialCharacters()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            var peter = new Person { Name = "Peter Parker", NickNames = new[] { "Spider-Man" } };
+            collection.Insert(peter);
+            try
+            {
+                // The hyphen is a tag special character; without escaping this query would be
+                // malformed / return the wrong results rather than matching "Spider-Man".
+                var res = await collection.Where(x => x.NickNames.MatchStartsWith("Spider-M")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Peter Parker", res[0].Name);
+            }
+            finally
+            {
+                await collection.DeleteAsync(new[] { peter });
             }
         }
 

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -1416,6 +1416,148 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal(existingRecordsCount, res.Count);
         }
 
+        // Seeds a known pair of people for the Match* functional tests. Clears any existing
+        // people first so the test is independent of ordering, and the caller is expected to
+        // clear again in a finally block so it does not pollute the shared Person collection.
+        private async Task<RedisCollection<Person>> SeedMatchPeopleAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            await collection.DeleteAsync(await collection.ToListAsync());
+
+            collection.Insert(new Person { Name = "Steve Lorello", NickNames = new[] { "Steve", "Stevie" } });
+            collection.Insert(new Person { Name = "Harry Potter", NickNames = new[] { "Harry", "Hazza" } });
+
+            return collection;
+        }
+
+        private async Task ClearPeopleAsync()
+        {
+            var collection = new RedisCollection<Person>(_connection);
+            await collection.DeleteAsync(await collection.ToListAsync());
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchStartsWith()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.Name.MatchStartsWith("Ste")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Steve Lorello", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchEndsWith()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.Name.MatchEndsWith("orello")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Steve Lorello", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchContains()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.Name.MatchContains("orell")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Steve Lorello", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchStartsWithStringArray()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.NickNames.MatchStartsWith("Ste")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Steve Lorello", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchEndsWithStringArray()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.NickNames.MatchEndsWith("vie")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Steve Lorello", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Fact]
+        public async Task TestSearchByMatchContainsStringArray()
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.NickNames.MatchContains("azz")).ToListAsync();
+
+                Assert.Single(res);
+                Assert.Equal("Harry Potter", res[0].Name);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData("Ste*", 1)]
+        [InlineData("*vie", 1)]
+        [InlineData("Ha*", 1)]
+        [InlineData("Nope*", 0)]
+        public async Task TestSearchByMatchPatternStringArray(string pattern, int existingRecordsCount)
+        {
+            var collection = await SeedMatchPeopleAsync();
+            try
+            {
+                var res = await collection.Where(x => x.NickNames.MatchPattern(pattern)).ToListAsync();
+
+                Assert.Equal(existingRecordsCount, res.Count);
+            }
+            finally
+            {
+                await ClearPeopleAsync();
+            }
+        }
+
         [Fact]
         public async Task TestUpdateByteArray()
         {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -429,7 +429,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestMatchStartsWith()
+        public void TestMatchStartsWithOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -446,7 +446,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
         
         [Fact]
-        public void TestMatchEndsWith()
+        public void TestMatchEndsWithOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -463,7 +463,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestMatchContains()
+        public void TestMatchContainsOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -497,7 +497,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void TestMatchPattern()
+        public void TestMatchPatternOfString()
         {
             _substitute.ClearSubstitute();
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
@@ -509,6 +509,77 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "FT.SEARCH",
                 "person-idx",
                 "(@Name:Ste* Lo*)",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchStartsWithOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchStartsWith("Ste")).ToList();
+            _substitute.Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{Ste*})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchEndsWithOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchEndsWith("Ste")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{*Ste})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchContainsOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchContains("Ste")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{*Ste*})",
+                "LIMIT",
+                "0",
+                "100");
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+        }
+
+        [Fact]
+        public void TestMatchPatternOfStringArray()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var ddfgdf = collection.Where(x => x.NickNames.MatchPattern("Ste* Lo*")).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{Ste* Lo*})",
                 "LIMIT",
                 "0",
                 "100");

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -436,7 +436,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             var collection = new RedisCollection<Person>(_substitute);
             _ = collection.Where(x => x.Name.MatchStartsWith("Ste")).ToList();
-            _substitute.Execute(
+            _substitute.Received().Execute(
                 "FT.SEARCH",
                 "person-idx",
                 "(@Name:Ste*)",
@@ -503,7 +503,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
 
             var collection = new RedisCollection<Person>(_substitute);
-            var ddfgdf = collection.Where(x => x.Name.MatchPattern("Ste* Lo*")).ToList();
+            _ = collection.Where(x => x.Name.MatchPattern("Ste* Lo*")).ToList();
 
             _substitute.Received().Execute(
                 "FT.SEARCH",
@@ -522,7 +522,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
 
             var collection = new RedisCollection<Person>(_substitute);
             _ = collection.Where(x => x.NickNames.MatchStartsWith("Ste")).ToList();
-            _substitute.Execute(
+            _substitute.Received().Execute(
                 "FT.SEARCH",
                 "person-idx",
                 "(@NickNames:{Ste*})",
@@ -563,8 +563,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 "LIMIT",
                 "0",
                 "100");
-            _substitute.ClearSubstitute();
-            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
         }
 
         [Fact]
@@ -574,7 +572,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
 
             var collection = new RedisCollection<Person>(_substitute);
-            var ddfgdf = collection.Where(x => x.NickNames.MatchPattern("Ste* Lo*")).ToList();
+            _ = collection.Where(x => x.NickNames.MatchPattern("Ste* Lo*")).ToList();
 
             _substitute.Received().Execute(
                 "FT.SEARCH",

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -584,6 +584,57 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestMatchStartsWithOfStringArrayEscapesTagChars()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchStartsWith("St-e@v")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{St\\-e\\@v*})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchEndsWithOfStringArrayEscapesTagChars()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchEndsWith("St-e@v")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{*St\\-e\\@v})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
+        public void TestMatchContainsOfStringArrayEscapesTagChars()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            _ = collection.Where(x => x.NickNames.MatchContains("St-e@v")).ToList();
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@NickNames:{*St\\-e\\@v*})",
+                "LIMIT",
+                "0",
+                "100");
+        }
+
+        [Fact]
         public void TestTagContains()
         {
             _substitute.ClearSubstitute();


### PR DESCRIPTION
Add
```
MatchStartsWith
MatchEndsWith
MatchContains
MatchPattern
```
for support `IEnumerable<string>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query translation for Match* methods and fixes prior incorrect Contains/Pattern shadow behavior, which can alter search results for tag fields and in-memory eval paths; risk is mitigated by broad new tests.
> 
> **Overview**
> Extends **`MatchStartsWith`**, **`MatchEndsWith`**, **`MatchContains`**, and **`MatchPattern`** so they work on **`IEnumerable<string>`** (tag-indexed fields like `NickNames`) in LINQ queries, not only on full-text **`string`** fields.
> 
> **Expression translation** (`ExpressionParserUtilities`) now branches on the receiver type: text fields keep the existing wildcard query shape; tag fields emit RediSearch tag syntax (`{...}`) with **`EscapeTagField`** on literals while preserving wildcards, including a case for hyphenated tags (e.g. `Spider-Man`).
> 
> **In-process “shadow” implementations** (`StringExtension`) add matching **`IEnumerable<string>`** overloads, fix **`MatchContains`** / **`MatchPattern`** on **`string`** (they incorrectly used **`EndsWith`**), use case-insensitive token checks, and implement **`MatchPattern`** via a **`WildcardToRegex`** helper aligned with Redis wildcard rules.
> 
> Coverage adds unit tests that assert generated **`FT.SEARCH`** query strings (including tag escaping) and functional Redis tests for text and tag **`Match*`** predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fc32540a11a05fb58b301380a7a6211259c8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->