### PR TITLE
Fix overlapping RediSearch prefixes

### DIFF
--- a/src/Redis.OM/Modeling/RedisIndex.cs
+++ b/src/Redis.OM/Modeling/RedisIndex.cs
@@ -284,7 +284,7 @@ namespace Redis.OM.Modeling
             if (objAttribute.Prefixes.Length > 0)
             {
                 args.Add(objAttribute.Prefixes.Length.ToString());
-                args.AddRange(objAttribute.Prefixes);
+                args.AddRange(objAttribute.Prefixes.Select(x => $"{x.TrimEnd(':')}:"));
             }
             else
             {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/OverlappingPrefixTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/OverlappingPrefixTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Redis.OM.Contracts;
+using Redis.OM.Modeling;
+using Redis.OM.Searching;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    [Collection("Redis")]
+    public class OverlappingPrefixTests
+    {
+        [Document(StorageType = StorageType.Json, IndexName = "prefix-player-idx", Prefixes = new[] { "Player" })]
+        private class PlayerPrefixDocument
+        {
+            [RedisIdField]
+            [Indexed]
+            public string Id { get; set; }
+
+            [Searchable]
+            public string Name { get; set; }
+        }
+
+        [Document(StorageType = StorageType.Json, IndexName = "prefix-player-state-idx", Prefixes = new[] { "PlayerState" })]
+        private class PlayerStatePrefixDocument
+        {
+            [RedisIdField]
+            [Indexed]
+            public string Id { get; set; }
+
+            [Searchable]
+            public string Status { get; set; }
+        }
+
+        private readonly IRedisConnection _connection;
+
+        public OverlappingPrefixTests(RedisSetup setup)
+        {
+            _connection = setup.Connection;
+        }
+
+        [Fact]
+        public async Task CollectionsWithOverlappingPrefixes_DoNotLeakResults()
+        {
+            CleanupArtifacts();
+
+            try
+            {
+                await _connection.CreateIndexAsync(typeof(PlayerPrefixDocument));
+                await _connection.CreateIndexAsync(typeof(PlayerStatePrefixDocument));
+
+                var playerCollection = new RedisCollection<PlayerPrefixDocument>(_connection);
+                var playerStateCollection = new RedisCollection<PlayerStatePrefixDocument>(_connection);
+
+                await playerCollection.InsertAsync(new PlayerPrefixDocument { Name = "alice" });
+                await playerStateCollection.InsertAsync(new PlayerStatePrefixDocument { Status = "online" });
+
+                var players = await playerCollection.ToListAsync();
+                var playerStates = await playerStateCollection.ToListAsync();
+
+                Assert.Single(players);
+                Assert.Equal("alice", players[0].Name);
+                Assert.Single(playerStates);
+                Assert.Equal("online", playerStates[0].Status);
+            }
+            finally
+            {
+                CleanupArtifacts();
+            }
+        }
+
+        private void CleanupArtifacts()
+        {
+            TryDropIndexAndAssociatedRecords(typeof(PlayerPrefixDocument));
+            TryDropIndexAndAssociatedRecords(typeof(PlayerStatePrefixDocument));
+            DeleteKeysByPattern("Player:*");
+            DeleteKeysByPattern("PlayerState:*");
+        }
+
+        private void DeleteKeysByPattern(string pattern)
+        {
+            var keys = _connection.Execute("KEYS", pattern).ToArray().Select(x => x.ToString()).ToArray();
+            if (keys.Length > 0)
+            {
+                _connection.Execute("DEL", keys.Cast<object>().ToArray());
+            }
+        }
+
+        private void TryDropIndexAndAssociatedRecords(Type type)
+        {
+            try
+            {
+                _connection.DropIndexAndAssociatedRecords(type);
+            }
+            catch (Exception ex) when (ex.Message.Contains("Unknown Index name") || ex.Message.Contains("no such index"))
+            {
+            }
+        }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/RedisIndexTests.cs
@@ -137,6 +137,14 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestIndexSerializationNormalizesPrefixDelimiter()
+        {
+            var indexArr = typeof(TestPersonClassHappyPathWithMutatedDefinition).SerializeIndex();
+
+            Assert.Equal("Simple:", indexArr[5]);
+        }
+
+        [Fact]
         public void TestCreateIndex()
         {
             var host = Environment.GetEnvironmentVariable("STANDALONE_HOST_PORT") ?? "localhost";


### PR DESCRIPTION
## Summary
- fixes #535 by normalizing configured index prefixes to always include the key delimiter in FT.CREATE
- adds a serialization regression test for custom prefixes without a trailing colon
- adds a Redis-backed regression test covering overlapping Player / PlayerState prefixes

## Root cause
Redis OM writes document keys as prefix:id, but custom index definitions were registered with the raw configured prefix. A prefix like Player therefore matched both Player:* and PlayerState:* during indexing and enumeration.

## Tests
- dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --framework net7.0 --filter "FullyQualifiedName~RedisIndexTests.TestIndexSerializationNormalizesPrefixDelimiter|FullyQualifiedName~OverlappingPrefixTests.CollectionsWithOverlappingPrefixes_DoNotLeakResults"
- attempted dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --framework net7.0 in a dirty local workspace; existing unrelated failures were already present outside this change set

## Risk
- low; the change is limited to how custom prefixes are serialized into RediSearch index definitions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to normalizing configured index `PREFIX` values (adding a trailing `:`), plus regression tests; main risk is altered matching for users who intentionally relied on non-delimited prefixes.
> 
> **Overview**
> Fixes RediSearch index creation to **normalize custom `DocumentAttribute.Prefixes`** by trimming any trailing `:` and always appending `:` before emitting the `PREFIX` args in `RedisIndex.SerializeIndex`, preventing overlapping prefixes (e.g., `Player` vs `PlayerState`) from matching each other.
> 
> Adds regression coverage: a serialization test ensuring prefixes like `"Simple"` become `"Simple:"`, and a Redis-backed test that two collections with overlapping prefixes return only their own records.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a22d8bf9b5f2d65dd66ba8c37b4d2511a70591f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->