### PR TITLE
Preserve Redis connection exceptions

### DIFF
--- a/src/Redis.OM/RedisConnection.cs
+++ b/src/Redis.OM/RedisConnection.cs
@@ -31,6 +31,14 @@ namespace Redis.OM
                 var result = _db.Execute(command, args);
                 return new RedisReply(result);
             }
+            catch (RedisConnectionException ex)
+            {
+                throw new RedisConnectionException(
+                    ex.FailureType,
+                    $"{ex.Message}{Environment.NewLine}Failed on {command} {string.Join(" ", args)}",
+                    ex,
+                    ex.CommandStatus);
+            }
             catch (Exception ex)
             {
                 throw new Exception($"{ex.Message}{Environment.NewLine}Failed on {command} {string.Join(" ", args)}", ex);
@@ -44,6 +52,14 @@ namespace Redis.OM
             {
                 var result = await _db.ExecuteAsync(command, args).ConfigureAwait(false);
                 return new RedisReply(result);
+            }
+            catch (RedisConnectionException ex)
+            {
+                throw new RedisConnectionException(
+                    ex.FailureType,
+                    $"{ex.Message}{Environment.NewLine}Failed on {command} {string.Join(" ", args)}",
+                    ex,
+                    ex.CommandStatus);
             }
             catch (Exception ex)
             {

--- a/test/Redis.OM.Unit.Tests/ConnectionTests.cs
+++ b/test/Redis.OM.Unit.Tests/ConnectionTests.cs
@@ -1,5 +1,10 @@
-﻿using StackExchange.Redis;
-using System;
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Redis.OM;
+using Redis.OM.Contracts;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests
@@ -8,6 +13,18 @@ namespace Redis.OM.Unit.Tests
     {
         private string STANDALONE_CONNECTION_STRING = "redis://localhost:6379";
         private string SENTINEL_CONNECTION_STRING = "redis://localhost:26379?sentinel_primary_name=redismaster";
+
+        private static IRedisConnection CreateThrowingConnection(Exception exception)
+        {
+            var multiplexer = Substitute.For<IConnectionMultiplexer>();
+            var database = Substitute.For<IDatabase>();
+
+            multiplexer.GetDatabase().Returns(database);
+            database.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Throws(exception);
+            database.ExecuteAsync(Arg.Any<string>(), Arg.Any<object[]>()).Returns(Task.FromException<RedisResult>(exception));
+
+            return new RedisConnectionProvider(multiplexer).Connection;
+        }
 
         [Fact]
         public void TestConnectStandalone()
@@ -83,6 +100,32 @@ namespace Redis.OM.Unit.Tests
             connection.Execute("SET", "Foo", "Bar");
             var res = connection.Execute("GET", "Foo");
             Assert.Equal("Bar",res);
+        }
+
+        [Fact]
+        public void Execute_PreservesRedisConnectionExceptionType()
+        {
+            var exception = new RedisConnectionException(ConnectionFailureType.SocketFailure, "connection failed");
+            var connection = CreateThrowingConnection(exception);
+
+            var ex = Assert.Throws<RedisConnectionException>(() => connection.Execute("PING", "foo"));
+
+            Assert.Equal(ConnectionFailureType.SocketFailure, ex.FailureType);
+            Assert.Same(exception, ex.InnerException);
+            Assert.Contains("Failed on PING foo", ex.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_PreservesRedisConnectionExceptionType()
+        {
+            var exception = new RedisConnectionException(ConnectionFailureType.SocketFailure, "connection failed");
+            var connection = CreateThrowingConnection(exception);
+
+            var ex = await Assert.ThrowsAsync<RedisConnectionException>(() => connection.ExecuteAsync("PING", "foo"));
+
+            Assert.Equal(ConnectionFailureType.SocketFailure, ex.FailureType);
+            Assert.Same(exception, ex.InnerException);
+            Assert.Contains("Failed on PING foo", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Issue #300\n\nRoot cause: RedisConnection wrapped every exception from IDatabase.Execute/ExecuteAsync in a plain Exception, which hid StackExchange.Redis connection exceptions from callers.\n\nFix: preserve RedisConnectionException in both sync and async paths while keeping the existing generic wrapping behavior for other failures.\n\nTests run: dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --filter "FullyQualifiedName~Redis.OM.Unit.Tests.ConnectionTests.Execute_PreservesRedisConnectionExceptionType|FullyQualifiedName~Redis.OM.Unit.Tests.ConnectionTests.ExecuteAsync_PreservesRedisConnectionExceptionType"\n\nRisk: non-connection exceptions still follow the existing wrapper path; this change only narrows the handling for Redis connection failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the exception type surfaced to callers for connection failures, which may affect downstream error handling, but is narrowly scoped to `RedisConnectionException` wrapping and adds targeted tests.
> 
> **Overview**
> Preserves `StackExchange.Redis` connection failure semantics by **rethrowing `RedisConnectionException`** (with added command/args context) from `RedisConnection.Execute` and `ExecuteAsync`, instead of wrapping it in a generic `Exception`.
> 
> Adds unit tests that stub `IDatabase` to throw and verify the thrown exception remains a `RedisConnectionException`, keeps the original `FailureType`, and includes the failed command in the message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 249b83732daff0d7064db0fef20410655f0d6ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->