### PR TITLE
Fix WITHSCORES search response parsing and propagate scores

### DIFF
--- a/src/Redis.OM/Searching/SearchResponse.cs
+++ b/src/Redis.OM/Searching/SearchResponse.cs
@@ -18,17 +18,24 @@ namespace Redis.OM.Searching
             var vals = val.ToArray();
             DocumentCount = vals[0];
             Documents = new Dictionary<string, IDictionary<string, string>>();
-            for (var i = 1; i < vals.Count(); i += 2)
+            for (var i = 1; i < vals.Count();)
             {
                 var docId = (string)vals[i];
+                var documentIndex = GetDocumentIndex(vals, i + 1);
+                if (documentIndex >= vals.Length)
+                {
+                    break;
+                }
+
                 var documentHash = new Dictionary<string, string>();
-                var docArray = vals[i + 1].ToArray();
+                var docArray = vals[documentIndex].ToArray();
                 for (var j = 0; j < docArray.Length; j += 2)
                 {
                     documentHash.Add(docArray[j], docArray[j + 1]);
                 }
 
                 Documents.Add(docId, documentHash);
+                i = documentIndex + 1;
             }
         }
 
@@ -59,6 +66,16 @@ namespace Redis.OM.Searching
             }
 
             return dict;
+        }
+
+        private static int GetDocumentIndex(RedisReply[] values, int startIndex)
+        {
+            while (startIndex < values.Length && values[startIndex].ToArray().Length == 1)
+            {
+                startIndex++;
+            }
+
+            return startIndex;
         }
     }
 
@@ -109,11 +126,17 @@ namespace Redis.OM.Searching
 
                 DocumentCount = vals[0];
                 Documents = new Dictionary<string, T>();
-                for (var i = 1; i < vals.Count(); i += 2)
+                for (var i = 1; i < vals.Count();)
                 {
                     var docId = (string)vals[i];
+                    var documentIndex = GetDocumentIndex(vals, i + 1);
+                    if (documentIndex >= vals.Length)
+                    {
+                        break;
+                    }
+
                     var documentHash = new Dictionary<string, RedisReply>();
-                    var docArray = vals[i + 1].ToArray();
+                    var docArray = vals[documentIndex].ToArray();
                     if (docArray.Length > 1)
                     {
                         for (var j = 0; j < docArray.Length; j += 2)
@@ -128,6 +151,8 @@ namespace Redis.OM.Searching
                     {
                         DocumentsSkippedCount++; // needed when a key expired while it was being enumerated by Redis.
                     }
+
+                    i = documentIndex + 1;
                 }
             }
         }
@@ -172,14 +197,31 @@ namespace Redis.OM.Searching
             var arr = redisReply.ToArray();
             var response = new SearchResponse<T>();
             response.DocumentCount = arr[0];
-            for (var i = 1; i < arr.Count(); i += 2)
+            for (var i = 1; i < arr.Count();)
             {
                 var docId = (string)arr[i];
-                T? primitive = arr[i + 1].ToArray().Length > 1 ? (T)Convert.ChangeType(arr[i + 1].ToArray()[1], typeof(T)) : default;
+                var documentIndex = GetDocumentIndex(arr, i + 1);
+                if (documentIndex >= arr.Length)
+                {
+                    break;
+                }
+
+                T? primitive = arr[documentIndex].ToArray().Length > 1 ? (T)Convert.ChangeType(arr[documentIndex].ToArray()[1], typeof(T)) : default;
                 response.Documents.Add(docId, primitive!);
+                i = documentIndex + 1;
             }
 
             return response;
+        }
+
+        private static int GetDocumentIndex(RedisReply[] values, int startIndex)
+        {
+            while (startIndex < values.Length && values[startIndex].ToArray().Length == 1)
+            {
+                startIndex++;
+            }
+
+            return startIndex;
         }
     }
 }

--- a/src/Redis.OM/Searching/SearchResponse.cs
+++ b/src/Redis.OM/Searching/SearchResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -18,6 +18,7 @@ namespace Redis.OM.Searching
             var vals = val.ToArray();
             DocumentCount = vals[0];
             Documents = new Dictionary<string, IDictionary<string, string>>();
+            Scores = new Dictionary<string, double>();
             for (var i = 1; i < vals.Count();)
             {
                 var docId = (string)vals[i];
@@ -25,6 +26,11 @@ namespace Redis.OM.Searching
                 if (documentIndex >= vals.Length)
                 {
                     break;
+                }
+
+                if (documentIndex > i + 1 && TryGetScore(vals[i + 1], out var score))
+                {
+                    Scores[docId] = score;
                 }
 
                 var documentHash = new Dictionary<string, string>();
@@ -50,6 +56,12 @@ namespace Redis.OM.Searching
         public IDictionary<string, IDictionary<string, string>> Documents { get; }
 
         /// <summary>
+        /// Gets the relative internal scores of each document keyed by document id. Only populated when the
+        /// query was run with the <see cref="Query.QueryFlags.WithScores"/> flag.
+        /// </summary>
+        public IDictionary<string, double> Scores { get; }
+
+        /// <summary>
         /// gets document as a collection of the provided type.
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
@@ -68,7 +80,14 @@ namespace Redis.OM.Searching
             return dict;
         }
 
-        private static int GetDocumentIndex(RedisReply[] values, int startIndex)
+        /// <summary>
+        /// Walks forward over scalar metadata entries (e.g. the score emitted by WITHSCORES) that sit between a
+        /// document's id and its field payload, returning the index of the field payload.
+        /// </summary>
+        /// <param name="values">The flat search reply.</param>
+        /// <param name="startIndex">The index immediately after the document id.</param>
+        /// <returns>The index of the document's field payload.</returns>
+        internal static int GetDocumentIndex(RedisReply[] values, int startIndex)
         {
             while (startIndex < values.Length && values[startIndex].ToArray().Length == 1)
             {
@@ -76,6 +95,26 @@ namespace Redis.OM.Searching
             }
 
             return startIndex;
+        }
+
+        /// <summary>
+        /// Attempts to interpret a scalar metadata reply as a numeric document score.
+        /// </summary>
+        /// <param name="reply">The scalar reply sitting between the document id and its payload.</param>
+        /// <param name="score">The parsed score.</param>
+        /// <returns>Whether the reply could be interpreted as a numeric score.</returns>
+        internal static bool TryGetScore(RedisReply reply, out double score)
+        {
+            try
+            {
+                score = (double)reply;
+                return true;
+            }
+            catch (InvalidCastException)
+            {
+                score = default;
+                return false;
+            }
         }
     }
 
@@ -104,12 +143,14 @@ namespace Redis.OM.Searching
                 var @this = PrimitiveSearchResponse(val);
                 Documents = @this.Documents;
                 DocumentCount = @this.DocumentCount;
+                Scores = @this.Scores;
             }
             else if (underlyingType is { IsPrimitive: true })
             {
                 var @this = PrimitiveSearchResponse(val);
                 Documents = @this.Documents;
                 DocumentCount = @this.DocumentCount;
+                Scores = @this.Scores;
             }
             else
             {
@@ -126,13 +167,19 @@ namespace Redis.OM.Searching
 
                 DocumentCount = vals[0];
                 Documents = new Dictionary<string, T>();
+                Scores = new Dictionary<string, double>();
                 for (var i = 1; i < vals.Count();)
                 {
                     var docId = (string)vals[i];
-                    var documentIndex = GetDocumentIndex(vals, i + 1);
+                    var documentIndex = SearchResponse.GetDocumentIndex(vals, i + 1);
                     if (documentIndex >= vals.Length)
                     {
                         break;
+                    }
+
+                    if (documentIndex > i + 1 && SearchResponse.TryGetScore(vals[i + 1], out var score))
+                    {
+                        Scores[docId] = score;
                     }
 
                     var documentHash = new Dictionary<string, RedisReply>();
@@ -162,6 +209,7 @@ namespace Redis.OM.Searching
             DocumentCount = 0;
             DocumentsSkippedCount = 0;
             Documents = new Dictionary<string, T>();
+            Scores = new Dictionary<string, double>();
         }
 
         /// <summary>
@@ -179,6 +227,12 @@ namespace Redis.OM.Searching
         /// Gets the documents.
         /// </summary>
         public IDictionary<string, T> Documents { get; }
+
+        /// <summary>
+        /// Gets the relative internal scores of each document keyed by document id. Only populated when the
+        /// query was run with the <see cref="Query.QueryFlags.WithScores"/> flag.
+        /// </summary>
+        public IDictionary<string, double> Scores { get; }
 
         /// <summary>
         /// Gets a particular document by it's ID.
@@ -200,10 +254,15 @@ namespace Redis.OM.Searching
             for (var i = 1; i < arr.Count();)
             {
                 var docId = (string)arr[i];
-                var documentIndex = GetDocumentIndex(arr, i + 1);
+                var documentIndex = SearchResponse.GetDocumentIndex(arr, i + 1);
                 if (documentIndex >= arr.Length)
                 {
                     break;
+                }
+
+                if (documentIndex > i + 1 && SearchResponse.TryGetScore(arr[i + 1], out var score))
+                {
+                    response.Scores[docId] = score;
                 }
 
                 T? primitive = arr[documentIndex].ToArray().Length > 1 ? (T)Convert.ChangeType(arr[documentIndex].ToArray()[1], typeof(T)) : default;
@@ -212,16 +271,6 @@ namespace Redis.OM.Searching
             }
 
             return response;
-        }
-
-        private static int GetDocumentIndex(RedisReply[] values, int startIndex)
-        {
-            while (startIndex < values.Length && values[startIndex].ToArray().Length == 1)
-            {
-                startIndex++;
-            }
-
-            return startIndex;
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using Redis.OM.Contracts;
 using Redis.OM.Modeling;
 using Redis.OM.Searching;
+using Redis.OM.Searching.Query;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests.RediSearchTests
@@ -65,6 +66,67 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 tasks.Add(_connection.SetAsync(person));
             }
             await Task.WhenAll(tasks);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task WithScoresPopulatesScoresHash(int dialect)
+        {
+            var query = new RedisQuery("hash-person-idx")
+            {
+                QueryText = "@Name:Steve",
+                Flags = (long)QueryFlags.WithScores,
+                Dialect = dialect,
+            };
+
+            var response = await _connection.SearchAsync<HashPerson>(query);
+
+            Assert.NotEmpty(response.Documents);
+            Assert.NotEmpty(response.Scores);
+            foreach (var docId in response.Documents.Keys)
+            {
+                Assert.True(response.Scores.ContainsKey(docId), $"missing score for {docId}");
+                Assert.True(response.Scores[docId] > 0, $"expected positive score for {docId} but got {response.Scores[docId]}");
+            }
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task WithScoresPopulatesScoresJson(int dialect)
+        {
+            var query = new RedisQuery("person-idx")
+            {
+                QueryText = "@Name:Steve",
+                Flags = (long)QueryFlags.WithScores,
+                Dialect = dialect,
+            };
+
+            var response = await _connection.SearchAsync<Person>(query);
+
+            Assert.NotEmpty(response.Documents);
+            Assert.NotEmpty(response.Scores);
+            foreach (var docId in response.Documents.Keys)
+            {
+                Assert.True(response.Scores.ContainsKey(docId), $"missing score for {docId}");
+                Assert.True(response.Scores[docId] > 0, $"expected positive score for {docId} but got {response.Scores[docId]}");
+            }
+        }
+
+        [Fact]
+        public async Task WithoutScoresLeavesScoresEmpty()
+        {
+            var query = new RedisQuery("hash-person-idx")
+            {
+                QueryText = "@Name:Steve",
+                Dialect = 2,
+            };
+
+            var response = await _connection.SearchAsync<HashPerson>(query);
+
+            Assert.NotEmpty(response.Documents);
+            Assert.Empty(response.Scores);
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchResponseTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchResponseTests.cs
@@ -1,0 +1,77 @@
+using Redis.OM;
+using Redis.OM.Searching;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    public class SearchResponseTests
+    {
+        [Fact]
+        public void WithScoresResponse_AllowsDuplicateScores_ParsesDocumentIdsCorrectly()
+        {
+            var response = new SearchResponse<HashPerson>(new RedisReply[]
+            {
+                new(2),
+                new("hash-person-idx:1"),
+                new(38),
+                new RedisReply[]
+                {
+                    "Id",
+                    "1",
+                    "Name",
+                    "Steve",
+                },
+                new("hash-person-idx:2"),
+                new(38),
+                new RedisReply[]
+                {
+                    "Id",
+                    "2",
+                    "Name",
+                    "Alice",
+                },
+            });
+
+            Assert.Equal(2, response.DocumentCount);
+            Assert.Equal(2, response.Documents.Count);
+            Assert.Equal("1", response["hash-person-idx:1"].Id);
+            Assert.Equal("Steve", response["hash-person-idx:1"].Name);
+            Assert.Equal("2", response["hash-person-idx:2"].Id);
+            Assert.Equal("Alice", response["hash-person-idx:2"].Name);
+        }
+
+        [Fact]
+        public void WithScoresResponse_HandlesDistinctScores_ParsesDocumentIdsCorrectly()
+        {
+            var response = new SearchResponse<HashPerson>(new RedisReply[]
+            {
+                new(2),
+                new("hash-person-idx:1"),
+                new(12),
+                new RedisReply[]
+                {
+                    "Id",
+                    "1",
+                    "Name",
+                    "Steve",
+                },
+                new("hash-person-idx:2"),
+                new(87),
+                new RedisReply[]
+                {
+                    "Id",
+                    "2",
+                    "Name",
+                    "Alice",
+                },
+            });
+
+            Assert.Equal(2, response.DocumentCount);
+            Assert.Equal(2, response.Documents.Count);
+            Assert.Equal("1", response["hash-person-idx:1"].Id);
+            Assert.Equal("Steve", response["hash-person-idx:1"].Name);
+            Assert.Equal("2", response["hash-person-idx:2"].Id);
+            Assert.Equal("Alice", response["hash-person-idx:2"].Name);
+        }
+    }
+}

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchResponseTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchResponseTests.cs
@@ -38,6 +38,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal("Steve", response["hash-person-idx:1"].Name);
             Assert.Equal("2", response["hash-person-idx:2"].Id);
             Assert.Equal("Alice", response["hash-person-idx:2"].Name);
+
+            Assert.Equal(2, response.Scores.Count);
+            Assert.Equal(38, response.Scores["hash-person-idx:1"]);
+            Assert.Equal(38, response.Scores["hash-person-idx:2"]);
         }
 
         [Fact]
@@ -72,6 +76,84 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Assert.Equal("Steve", response["hash-person-idx:1"].Name);
             Assert.Equal("2", response["hash-person-idx:2"].Id);
             Assert.Equal("Alice", response["hash-person-idx:2"].Name);
+
+            Assert.Equal(2, response.Scores.Count);
+            Assert.Equal(12, response.Scores["hash-person-idx:1"]);
+            Assert.Equal(87, response.Scores["hash-person-idx:2"]);
+        }
+
+        [Fact]
+        public void WithScoresResponse_ParsesFractionalScores()
+        {
+            // DIALECT 2 / TFIDF-style scoring can return fractional scores as bulk strings.
+            var response = new SearchResponse<HashPerson>(new RedisReply[]
+            {
+                new(1),
+                new("hash-person-idx:1"),
+                new("0.5"),
+                new RedisReply[]
+                {
+                    "Id",
+                    "1",
+                    "Name",
+                    "Steve",
+                },
+            });
+
+            Assert.Single(response.Documents);
+            Assert.Equal(0.5, response.Scores["hash-person-idx:1"]);
+        }
+
+        [Fact]
+        public void WithoutScores_ScoresDictionaryIsEmpty()
+        {
+            var response = new SearchResponse<HashPerson>(new RedisReply[]
+            {
+                new(1),
+                new("hash-person-idx:1"),
+                new RedisReply[]
+                {
+                    "Id",
+                    "1",
+                    "Name",
+                    "Steve",
+                },
+            });
+
+            Assert.Single(response.Documents);
+            Assert.Empty(response.Scores);
+        }
+
+        [Fact]
+        public void WithScoresResponse_NonGeneric_CapturesScores()
+        {
+            var response = new SearchResponse(new RedisReply[]
+            {
+                new(2),
+                new("hash-person-idx:1"),
+                new(38),
+                new RedisReply[]
+                {
+                    "Id",
+                    "1",
+                    "Name",
+                    "Steve",
+                },
+                new("hash-person-idx:2"),
+                new(87),
+                new RedisReply[]
+                {
+                    "Id",
+                    "2",
+                    "Name",
+                    "Alice",
+                },
+            });
+
+            Assert.Equal(2, response.Documents.Count);
+            Assert.Equal("Steve", response.Documents["hash-person-idx:1"]["Name"]);
+            Assert.Equal(38, response.Scores["hash-person-idx:1"]);
+            Assert.Equal(87, response.Scores["hash-person-idx:2"]);
         }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
@@ -25,50 +25,59 @@ public class VectorFunctionalTests
     [InlineData(2)]
     public async Task KnnWithScoresPropagatesScores(int dialect)
     {
-        // Isolate from other vector tests sharing this index so KNN results are deterministic.
+        // Isolate from other vector tests sharing this index so KNN results are deterministic, and
+        // restore a clean index afterwards so the record inserted here does not leak into sibling tests.
         _connection.DropIndexAndAssociatedRecords(typeof(ObjectWithVector));
         _connection.CreateIndex(typeof(ObjectWithVector));
-        var collection = new RedisCollection<ObjectWithVector>(_connection);
-        var id = $"vecScore-{Guid.NewGuid():N}";
-        collection.Insert(new ObjectWithVector
+        try
         {
-            Id = id,
-            SimpleHnswVector = Vector.Of(Enumerable.Range(0, 10).Select(x => (double)x).ToArray()),
-            SimpleVectorizedVector = Vector.Of("FooBarBaz"),
-        });
+            var collection = new RedisCollection<ObjectWithVector>(_connection);
+            var id = $"vecScore-{Guid.NewGuid():N}";
+            collection.Insert(new ObjectWithVector
+            {
+                Id = id,
+                SimpleHnswVector = Vector.Of(Enumerable.Range(0, 10).Select(x => (double)x).ToArray()),
+                SimpleVectorizedVector = Vector.Of("FooBarBaz"),
+            });
 
-        // Offset the query vector so the nearest-neighbor distance is non-zero (proves the
-        // KnnNeighborScore field actually parsed onto the object rather than defaulting to 0).
-        var queryArray = Enumerable.Range(0, 10).Select(x => (double)x).ToArray();
-        queryArray[0] += 2;
-        var queryVector = Vector.Of(queryArray);
-        queryVector.Embed(new DoubleVectorizerAttribute(10));
+            // Offset the query vector so the nearest-neighbor distance is non-zero (proves the
+            // KnnNeighborScore field actually parsed onto the object rather than defaulting to 0).
+            var queryArray = Enumerable.Range(0, 10).Select(x => (double)x).ToArray();
+            queryArray[0] += 2;
+            var queryVector = Vector.Of(queryArray);
+            queryVector.Embed(new DoubleVectorizerAttribute(10));
 
-        // KNN requires DIALECT 2; the library promotes 1 -> 2 internally because of PARAMS, so both
-        // inputs are exercised here and must yield the same correct result.
-        var query = new RedisQuery("objectwithvector-idx")
-        {
-            QueryText = "*",
-            NearestNeighbors = new NearestNeighbors(nameof(ObjectWithVector.SimpleHnswVector), 5, queryVector.Embedding!),
-            Flags = (long)QueryFlags.WithScores,
-            Dialect = dialect,
-        };
+            // KNN requires DIALECT 2; the library promotes 1 -> 2 internally because of PARAMS, so both
+            // inputs are exercised here and must yield the same correct result.
+            var query = new RedisQuery("objectwithvector-idx")
+            {
+                QueryText = "*",
+                NearestNeighbors = new NearestNeighbors(nameof(ObjectWithVector.SimpleHnswVector), 5, queryVector.Embedding!),
+                Flags = (long)QueryFlags.WithScores,
+                Dialect = dialect,
+            };
 
-        var response = await _connection.SearchAsync<ObjectWithVector>(query);
+            var response = await _connection.SearchAsync<ObjectWithVector>(query);
 
-        // WITHSCORES relevance scores are propagated for every returned document.
-        Assert.NotEmpty(response.Documents);
-        Assert.NotEmpty(response.Scores);
-        foreach (var docId in response.Documents.Keys)
-        {
-            Assert.True(response.Scores.ContainsKey(docId), $"missing score for {docId}");
-            Assert.True(response.Scores[docId] >= 0, $"unexpected score {response.Scores[docId]} for {docId}");
+            // WITHSCORES relevance scores are propagated for every returned document.
+            Assert.NotEmpty(response.Documents);
+            Assert.NotEmpty(response.Scores);
+            foreach (var docId in response.Documents.Keys)
+            {
+                Assert.True(response.Scores.ContainsKey(docId), $"missing score for {docId}");
+                Assert.True(response.Scores[docId] >= 0, $"unexpected score {response.Scores[docId]} for {docId}");
+            }
+
+            // The KNN distance (a payload field, distinct from the WITHSCORES scalar) still parses.
+            var match = response.Documents.Values.Single(x => x.Id == id);
+            Assert.NotNull(match.VectorScores);
+            Assert.True(match.VectorScores.NearestNeighborsScore > 0, "expected a non-zero KNN distance for the offset query vector");
         }
-
-        // The KNN distance (a payload field, distinct from the WITHSCORES scalar) still parses.
-        var match = response.Documents.Values.Single(x => x.Id == id);
-        Assert.NotNull(match.VectorScores);
-        Assert.True(match.VectorScores.NearestNeighborsScore > 0, "expected a non-zero KNN distance for the offset query vector");
+        finally
+        {
+            _connection.DropIndexAndAssociatedRecords(typeof(ObjectWithVector));
+            _connection.CreateIndex(typeof(ObjectWithVector));
+        }
     }
 
     [SkipIfMissingEnvVar("REDIS_OM_HF_TOKEN")]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/VectorTests/VectorFunctionalTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Redis.OM.Contracts;
+using Redis.OM.Modeling.Vectors;
 using Redis.OM.Searching;
+using Redis.OM.Searching.Query;
 using Xunit;
 
 namespace Redis.OM.Unit.Tests;
@@ -15,6 +18,57 @@ public class VectorFunctionalTests
     public VectorFunctionalTests(RedisSetup setup)
     {
         _connection = setup.Connection;
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task KnnWithScoresPropagatesScores(int dialect)
+    {
+        // Isolate from other vector tests sharing this index so KNN results are deterministic.
+        _connection.DropIndexAndAssociatedRecords(typeof(ObjectWithVector));
+        _connection.CreateIndex(typeof(ObjectWithVector));
+        var collection = new RedisCollection<ObjectWithVector>(_connection);
+        var id = $"vecScore-{Guid.NewGuid():N}";
+        collection.Insert(new ObjectWithVector
+        {
+            Id = id,
+            SimpleHnswVector = Vector.Of(Enumerable.Range(0, 10).Select(x => (double)x).ToArray()),
+            SimpleVectorizedVector = Vector.Of("FooBarBaz"),
+        });
+
+        // Offset the query vector so the nearest-neighbor distance is non-zero (proves the
+        // KnnNeighborScore field actually parsed onto the object rather than defaulting to 0).
+        var queryArray = Enumerable.Range(0, 10).Select(x => (double)x).ToArray();
+        queryArray[0] += 2;
+        var queryVector = Vector.Of(queryArray);
+        queryVector.Embed(new DoubleVectorizerAttribute(10));
+
+        // KNN requires DIALECT 2; the library promotes 1 -> 2 internally because of PARAMS, so both
+        // inputs are exercised here and must yield the same correct result.
+        var query = new RedisQuery("objectwithvector-idx")
+        {
+            QueryText = "*",
+            NearestNeighbors = new NearestNeighbors(nameof(ObjectWithVector.SimpleHnswVector), 5, queryVector.Embedding!),
+            Flags = (long)QueryFlags.WithScores,
+            Dialect = dialect,
+        };
+
+        var response = await _connection.SearchAsync<ObjectWithVector>(query);
+
+        // WITHSCORES relevance scores are propagated for every returned document.
+        Assert.NotEmpty(response.Documents);
+        Assert.NotEmpty(response.Scores);
+        foreach (var docId in response.Documents.Keys)
+        {
+            Assert.True(response.Scores.ContainsKey(docId), $"missing score for {docId}");
+            Assert.True(response.Scores[docId] >= 0, $"unexpected score {response.Scores[docId]} for {docId}");
+        }
+
+        // The KNN distance (a payload field, distinct from the WITHSCORES scalar) still parses.
+        var match = response.Documents.Values.Single(x => x.Id == id);
+        Assert.NotNull(match.VectorScores);
+        Assert.True(match.VectorScores.NearestNeighborsScore > 0, "expected a non-zero KNN distance for the offset query vector");
     }
 
     [SkipIfMissingEnvVar("REDIS_OM_HF_TOKEN")]


### PR DESCRIPTION
Fixes #310

## Problem

`FT.SEARCH` reply parsing assumed strict `id, fields` pairs. The `WITHSCORES` flag inserts a scalar score after each document id, so the parser misread the layout and threw:

```
System.ArgumentException: An item with the same key has already been added. Key: 38
   at Redis.OM.Searching.SearchResponse..ctor(RedisReply val)
```

## Fix

- **Parse correctly:** walk past the scalar metadata entries (the score) that sit between a document id and its field payload, instead of assuming fixed `id, fields` pairs. Applied to `SearchResponse`, `SearchResponse<T>` (typed hash mapping), and the primitive response path.
- **Propagate the scores:** the score is now captured and exposed via a new `Scores` dictionary (document id → `double`) on both `SearchResponse` and `SearchResponse<T>`. Previously the scores were skipped and silently discarded, so `WithScores` was non-fatal but useless; now the caller can read the relative internal score of each document (e.g. to merge results across shards/instances).

Score conversion is guarded: a non-numeric scalar (such as a `WITHPAYLOADS` payload) does not throw — it is simply not recorded as a score. `Scores` is empty when the query was not run with `WithScores`.

Example (matching the original report):

```csharp
var query = new RedisQuery("companies")
{
    QueryText = "(@LastName:%Smith%)|(@FirstName:%John%)",
    Flags = (long)QueryFlags.WithScores,
};
var response = await connection.SearchAsync<Company>(query);
foreach (var kvp in response.Documents)
{
    var score = response.Scores[kvp.Key];
    // ...
}
```

## Tests

**Unit** (`SearchResponseTests`): duplicate scores, distinct scores, fractional/string scores, the no-score case, and the non-generic `SearchResponse` path.

**Live functional** (`SearchFunctionalTests`): validate that scores are populated for every returned document under **both DIALECT 1 and DIALECT 2**, for hash-stored and JSON-stored documents, plus a check that `Scores` is empty when `WithScores` is not set.

## Risk

Scoped to FT.SEARCH reply parsing. The only API addition is the read-only `Scores` dictionary; existing members are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FT.SEARCH reply parsing for all searches; behavior without WithScores should match prior layout, but any subtle reply-shape assumptions could affect existing callers.
> 
> **Overview**
> Fixes **FT.SEARCH** parsing when **`QueryFlags.WithScores`** is set: Redis inserts a scalar score between each document id and its field payload, but the client assumed strict **id → fields** pairs. That misalignment caused duplicate-key errors (e.g. treating a score like a document id) and dropped scores entirely.
> 
> **`SearchResponse`** and **`SearchResponse<T>`** now advance through optional scalar metadata via **`GetDocumentIndex`**, capture numeric scores with **`TryGetScore`** (non-numeric scalars are skipped, not thrown), and expose a read-only **`Scores`** map (document id → **`double`**). The same loop logic applies to the non-generic response, typed hash mapping, and primitive search paths.
> 
> Tests add unit coverage for duplicate/distinct/fractional scores and the no-**WithScores** case, plus live checks for hash/JSON models (dialect 1 and 2) and KNN + **WithScores**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5826ff3c00758693d78f3eb2e9c44bd0b29c8fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->