### PR TITLE
Fix IQueryable select projection path

### DIFF
--- a/src/Redis.OM/Searching/RedisQueryProvider.cs
+++ b/src/Redis.OM/Searching/RedisQueryProvider.cs
@@ -77,18 +77,20 @@ namespace Redis.OM.Searching
         /// <inheritdoc/>
         public IQueryable CreateQuery(Expression expression)
         {
-            Type elementType = expression.Type;
+            Type elementType = GetElementType(expression.Type);
             try
             {
-                return
-                   (IQueryable)Activator.CreateInstance(
-                       typeof(RedisCollection<>).MakeGenericType(elementType),
-                       this,
-                       expression,
-                       StateManager,
-                       null,
-                       _saveState,
-                       _chunkSize);
+                var rootType = expression is MethodCallExpression methodCall ? GetRootType(methodCall) : elementType;
+                var collectionType = typeof(RedisCollection<>).MakeGenericType(elementType);
+                var arguments = new object?[] { this, expression, StateManager, null, _saveState, _chunkSize };
+                var instance = Activator.CreateInstance(
+                    collectionType,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    arguments,
+                    null);
+                SetRootType(instance, rootType);
+                return (IQueryable)instance!;
             }
             catch (TargetInvocationException e)
             {
@@ -106,7 +108,13 @@ namespace Redis.OM.Searching
             where TElement : notnull
         {
             var booleanExpression = expression as Expression<Func<TElement, bool>>;
-            return new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, _saveState, _chunkSize);
+            var collection = new RedisCollection<TElement>(this, expression, StateManager, booleanExpression, _saveState, _chunkSize);
+            if (expression is MethodCallExpression methodCall)
+            {
+                collection.RootType = GetRootType(methodCall);
+            }
+
+            return collection;
         }
 
         /// <inheritdoc/>
@@ -284,6 +292,40 @@ namespace Redis.OM.Searching
             }
 
             throw new NotImplementedException();
+        }
+
+        private static Type GetElementType(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                return type.GetGenericArguments()[0];
+            }
+
+            var queryableType = type.GetInterfaces()
+                .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IQueryable<>));
+            if (queryableType != null)
+            {
+                return queryableType.GetGenericArguments()[0];
+            }
+
+            var enumerableType = type.GetInterfaces()
+                .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+            if (enumerableType != null)
+            {
+                return enumerableType.GetGenericArguments()[0];
+            }
+
+            return type;
+        }
+
+        private static void SetRootType(object? collection, Type rootType)
+        {
+            if (collection == null)
+            {
+                return;
+            }
+
+            collection.GetType().GetProperty("RootType", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.SetValue(collection, rootType);
         }
 
         private static RedisReply InvariantCultureResultParsing<T>(RedisReply value)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -128,6 +128,40 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void SelectObjectProjectionViaNonGenericQueryProvider()
+        {
+            var marker = $"issue-507-object-{Guid.NewGuid():N}";
+            var collection = new RedisCollection<SelectTestObject>(_connection);
+            collection.Insert(new SelectTestObject
+            {
+                Name = marker,
+                Field1 = new InnerObject(),
+                Field2 = new InnerObject(),
+            });
+
+            var selectParameter = Expression.Parameter(typeof(SelectTestObject), "x");
+            var projectionConstructor = typeof(ProjectedSelectName).GetConstructor(Type.EmptyTypes);
+            var selectMethod = typeof(Queryable).GetMethods()
+                .Single(m => m.Name == nameof(Queryable.Select)
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
+                .MakeGenericMethod(typeof(SelectTestObject), typeof(ProjectedSelectName));
+            var selector = Expression.Lambda<Func<SelectTestObject, ProjectedSelectName>>(
+                Expression.MemberInit(
+                    Expression.New(projectionConstructor!),
+                    Expression.Bind(
+                        typeof(ProjectedSelectName).GetProperty(nameof(ProjectedSelectName.Name))!,
+                        Expression.PropertyOrField(selectParameter, nameof(SelectTestObject.Name)))),
+                selectParameter);
+            var selectCall = Expression.Call(null, selectMethod, collection.Expression, Expression.Quote(selector));
+
+            var projected = (IQueryable<ProjectedSelectName>)collection.Provider.CreateQuery(selectCall);
+            var names = projected.Select(x => x.Name).ToArray();
+
+            Assert.Contains(marker, names);
+        }
+
+        [Fact]
         public void TestLimit()
         {
             var collection = new RedisCollection<Person>(_connection);
@@ -1682,5 +1716,10 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 x.Inner.ShortList.Contains((short)200)).ToListAsync();
             Assert.Single(res);
         }
+    }
+
+    public class ProjectedSelectName
+    {
+        public string Name { get; set; }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Redis.OM.Contracts;
@@ -100,6 +101,30 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             {
                 Assert.True(age >= 0 || age == null);
             }
+        }
+
+        [Fact]
+        public void SelectNameViaNonGenericQueryProvider()
+        {
+            var marker = $"issue-507-{Guid.NewGuid():N}";
+            var collection = new RedisCollection<Person>(_connection);
+            collection.Insert(new Person { Name = marker, Age = 42 });
+
+            var selectParameter = Expression.Parameter(typeof(Person), "x");
+            var selectMethod = typeof(Queryable).GetMethods()
+                .Single(m => m.Name == nameof(Queryable.Select)
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
+                .MakeGenericMethod(typeof(Person), typeof(string));
+            var selector = Expression.Lambda<Func<Person, string>>(
+                Expression.PropertyOrField(selectParameter, nameof(Person.Name)),
+                selectParameter);
+            var selectCall = Expression.Call(null, selectMethod, collection.Expression, Expression.Quote(selector));
+
+            var projected = (IQueryable<string>)collection.Provider.CreateQuery(selectCall);
+            var names = projected.ToArray();
+
+            Assert.Contains(marker, names);
         }
 
         [Fact]

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchFunctionalTests.cs
@@ -128,40 +128,6 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
-        public void SelectObjectProjectionViaNonGenericQueryProvider()
-        {
-            var marker = $"issue-507-object-{Guid.NewGuid():N}";
-            var collection = new RedisCollection<SelectTestObject>(_connection);
-            collection.Insert(new SelectTestObject
-            {
-                Name = marker,
-                Field1 = new InnerObject(),
-                Field2 = new InnerObject(),
-            });
-
-            var selectParameter = Expression.Parameter(typeof(SelectTestObject), "x");
-            var projectionConstructor = typeof(ProjectedSelectName).GetConstructor(Type.EmptyTypes);
-            var selectMethod = typeof(Queryable).GetMethods()
-                .Single(m => m.Name == nameof(Queryable.Select)
-                    && m.GetParameters().Length == 2
-                    && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
-                .MakeGenericMethod(typeof(SelectTestObject), typeof(ProjectedSelectName));
-            var selector = Expression.Lambda<Func<SelectTestObject, ProjectedSelectName>>(
-                Expression.MemberInit(
-                    Expression.New(projectionConstructor!),
-                    Expression.Bind(
-                        typeof(ProjectedSelectName).GetProperty(nameof(ProjectedSelectName.Name))!,
-                        Expression.PropertyOrField(selectParameter, nameof(SelectTestObject.Name)))),
-                selectParameter);
-            var selectCall = Expression.Call(null, selectMethod, collection.Expression, Expression.Quote(selector));
-
-            var projected = (IQueryable<ProjectedSelectName>)collection.Provider.CreateQuery(selectCall);
-            var names = projected.Select(x => x.Name).ToArray();
-
-            Assert.Contains(marker, names);
-        }
-
-        [Fact]
         public void TestLimit()
         {
             var collection = new RedisCollection<Person>(_connection);
@@ -1716,10 +1682,5 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
                 x.Inner.ShortList.Contains((short)200)).ToListAsync();
             Assert.Single(res);
         }
-    }
-
-    public class ProjectedSelectName
-    {
-        public string Name { get; set; }
     }
 }

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -806,6 +806,53 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestSelectViaNonGenericQueryProvider()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<Person>(_substitute);
+            var sourceParameter = Expression.Parameter(typeof(Person), "x");
+            var selectParameter = Expression.Parameter(typeof(Person), "x");
+            var whereMethod = typeof(Queryable).GetMethods()
+                .Single(m => m.Name == nameof(Queryable.Where)
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
+                .MakeGenericMethod(typeof(Person));
+            var selectMethod = typeof(Queryable).GetMethods()
+                .Single(m => m.Name == nameof(Queryable.Select)
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
+                .MakeGenericMethod(typeof(Person), typeof(string));
+            var predicate = Expression.Lambda<Func<Person, bool>>(
+                Expression.Equal(
+                    Expression.PropertyOrField(sourceParameter, nameof(Person.Name)),
+                    Expression.Constant("Steve")),
+                sourceParameter);
+            var selector = Expression.Lambda<Func<Person, string>>(
+                Expression.PropertyOrField(selectParameter, nameof(Person.Name)),
+                selectParameter);
+            var whereCall = Expression.Call(null, whereMethod, collection.Expression, Expression.Quote(predicate));
+            var selectCall = Expression.Call(null, selectMethod, whereCall, Expression.Quote(selector));
+
+            var projected = collection.Provider.CreateQuery(selectCall);
+
+            Assert.IsType<RedisCollection<string>>(projected);
+            ((IQueryable<string>)projected).ToList();
+
+            _substitute.Received().Execute(
+                "FT.SEARCH",
+                "person-idx",
+                "(@Name:\"Steve\")",
+                "LIMIT",
+                "0",
+                "100",
+                "RETURN",
+                "1",
+                "Name");
+        }
+
+        [Fact]
         public void TestSelectComplexAnonType()
         {
             _substitute.ClearSubstitute();


### PR DESCRIPTION
Issue: #507

Root cause: `IQueryProvider.CreateQuery(Expression)` was using the full `IQueryable<T>` type as the collection generic argument and then invoking the internal `RedisCollection<T>` constructor with public-only reflection, so projected queries failed before enumeration.

Fix: derive the sequence element type from the query expression, invoke the internal constructor with non-public binding flags, and preserve the original document root type on projected collections.

Tests run:
- `dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --filter FullyQualifiedName~Redis.OM.Unit.Tests.RediSearchTests.SearchTests.TestSelectViaNonGenericQueryProvider --no-restore`
- `dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj -f net7.0 --filter FullyQualifiedName~Redis.OM.Unit.Tests.RediSearchTests.SearchFunctionalTests.SelectNameViaNonGenericQueryProvider --no-restore`
- `dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj -f net6.0 --filter FullyQualifiedName~Redis.OM.Unit.Tests.RediSearchTests.SearchFunctionalTests.SelectNameViaNonGenericQueryProvider --no-restore`

Risk: low. The change is scoped to query-provider instantiation for projected queryables; the main remaining risk is compatibility with other expression shapes that also flow through non-generic `CreateQuery`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, scoped to `RedisQueryProvider.CreateQuery(Expression)` instantiation logic for projected queryables; primary risk is unexpected element/root type inference for uncommon expression shapes.
> 
> **Overview**
> Fixes projection queries created via the non-generic `IQueryProvider.CreateQuery(Expression)` path so `Select`/chained projections no longer fail before enumeration.
> 
> The provider now derives the *sequence element type* from the expression type, uses reflection that can invoke non-public `RedisCollection<T>` constructors, and preserves the original document `RootType` on projected collections. Adds unit + functional coverage for selecting `Name` via manually-built `Queryable.Select` expressions using the non-generic provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5237572b08b3f2af8dd4cf1221e4e56b77105496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->