### PR TITLE
Fail fast on null/missing queries against IndexEmptyAndMissing = false fields

### DIFF
--- a/src/Redis.OM/Common/ExpressionTranslator.cs
+++ b/src/Redis.OM/Common/ExpressionTranslator.cs
@@ -424,6 +424,7 @@ namespace Redis.OM.Common
 
                 if (rightResolvesToNull)
                 {
+                    GuardNullQueryAgainstUnindexedMissing(binExpression.Left);
                     dialectNeeded |= 1 << 1;
                     return binExpression.NodeType switch
                     {
@@ -491,6 +492,32 @@ namespace Redis.OM.Common
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Validates that a null/missing query is only generated against a field that is actually indexed for
+        /// missing values. A field declared with <c>IndexEmptyAndMissing = false</c> is created without the
+        /// <c>INDEXMISSING</c> tag, so an <c>ismissing(...)</c> predicate against it is rejected by RediSearch with
+        /// an opaque syntax error. Surface that as an actionable exception at query-build time instead.
+        /// </summary>
+        /// <param name="left">The left-hand operand of the null comparison.</param>
+        private static void GuardNullQueryAgainstUnindexedMissing(Expression left)
+        {
+            var memberExpression = left as MemberExpression
+                                   ?? (left as UnaryExpression)?.Operand as MemberExpression;
+
+            if (memberExpression == null)
+            {
+                return;
+            }
+
+            var attribute = ExpressionParserUtilities.DetermineSearchAttribute(memberExpression);
+            if (attribute != null && !attribute.IndexEmptyAndMissing)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot query the field '{memberExpression.Member.Name}' for null/missing values because it is indexed with IndexEmptyAndMissing = false. " +
+                    "Set IndexEmptyAndMissing = true (the default) on the field and re-create the index to query for missing values, or remove the null check from your query.");
+            }
         }
 
         /// <summary>

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithNullableStrings.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/ObjectWithNullableStrings.cs
@@ -29,6 +29,17 @@ public class ObjectWithNullableStrings
     public AnEnum? Enum { get; set; }
 }
 
+[Document(StorageType = StorageType.Json)]
+public class ObjectWithNoMissingIndex
+{
+    [RedisIdField]
+    [Indexed]
+    public string Id { get; set; }
+
+    [Searchable(IndexEmptyAndMissing = false)]
+    public string? LastName { get; set; }
+}
+
 [Document]
 public class ObjectWithNullableStringsHash
 {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -4357,6 +4357,28 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestContainsOnNullableSearchableStringWithSelectAndNotNull()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<ObjectWithNullableStrings>(_substitute);
+            var queryString = collection
+                .Where(x => x.String2 != null && x.String2.Contains("Fal"))
+                .Select(x => new ObjectWithNullableStrings
+                {
+                    Id = x.Id,
+                    String2 = x.String2
+                })
+                .Take(11)
+                .ToQueryString();
+
+            Assert.Equal(
+                "\"FT.SEARCH\" \"objectwithnullablestrings-idx\" \"(-(ismissing(@String2)) (@String2:Fal))\" \"DIALECT\" \"2\" \"LIMIT\" \"0\" \"11\" \"RETURN\" \"6\" \"Id\" \"AS\" \"Id\" \"String2\" \"AS\" \"String2\"",
+                queryString);
+        }
+
+        [Fact]
         public async Task TestIsNotNull()
         {
             _substitute.ClearSubstitute();

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -4379,6 +4379,42 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public void TestNullCheckOnFieldWithIndexEmptyAndMissingFalseThrows()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<ObjectWithNoMissingIndex>(_substitute);
+
+            // A field declared with IndexEmptyAndMissing = false is created without INDEXMISSING, so an
+            // ismissing(...) predicate against it is rejected by RediSearch with an opaque syntax error.
+            // Surface that as an actionable exception at query-build time instead. (Issue #536)
+            var notNull = Assert.Throws<InvalidOperationException>(
+                () => collection.Where(x => x.LastName != null && x.LastName.Contains("Fal")).ToQueryString());
+            Assert.Contains("IndexEmptyAndMissing", notNull.Message);
+
+            var isNull = Assert.Throws<InvalidOperationException>(
+                () => collection.Where(x => x.LastName == null).ToQueryString());
+            Assert.Contains("IndexEmptyAndMissing", isNull.Message);
+        }
+
+        [Fact]
+        public void TestContainsOnFieldWithIndexEmptyAndMissingFalse()
+        {
+            _substitute.ClearSubstitute();
+            _substitute.Execute(Arg.Any<string>(), Arg.Any<object[]>()).Returns(_mockReply);
+
+            var collection = new RedisCollection<ObjectWithNoMissingIndex>(_substitute);
+
+            // A plain contains (without a null guard) must still work against such a field.
+            var queryString = collection.Where(x => x.LastName.Contains("Fal")).ToQueryString();
+
+            Assert.Equal(
+                "\"FT.SEARCH\" \"objectwithnomissingindex-idx\" \"(@LastName:Fal)\" \"LIMIT\" \"0\" \"100\"",
+                queryString);
+        }
+
+        [Fact]
         public async Task TestIsNotNull()
         {
             _substitute.ClearSubstitute();


### PR DESCRIPTION
Fixes #536

## Problem

Querying a field that is indexed with `IndexEmptyAndMissing = false` for null/missing values produced an `ismissing(...)` predicate. Because such a field's index is created **without** `INDEXMISSING`, RediSearch rejects the query with an opaque server-side error:

```
StackExchange.Redis.RedisServerException: Syntax error at offset 21 near LastName
```

In the original report (`LastName` declared as `[Searchable(IndexEmptyAndMissing = false)]`), a query that included a null guard serialized to:

```
FT.SEARCH graph3:user:idx ((ismissing(@LastName)) (@LastName:Fal)) DIALECT 2 ...
```

`ismissing(@LastName)` is invalid against that field, so the server throws. The user has no clear indication that the cause is the `IndexEmptyAndMissing = false` setting on the field.

## Fix

Detect this case at query-build time in `ExpressionTranslator` and throw an actionable `InvalidOperationException` that names the offending field and explains the requirement, instead of emitting a query the server cannot parse:

> Cannot query the field 'LastName' for null/missing values because it is indexed with IndexEmptyAndMissing = false. Set IndexEmptyAndMissing = true (the default) on the field and re-create the index to query for missing values, or remove the null check from your query.

RediSearch fundamentally cannot evaluate `ismissing()` on a field that was not indexed with `INDEXMISSING`, so the library cannot make the query succeed — failing fast with a clear, remediable error is the correct behavior.

Plain queries without a null guard (e.g. `Contains`) on such a field are unaffected and continue to work.

## Tests

- `TestNullCheckOnFieldWithIndexEmptyAndMissingFalseThrows` — asserts both `!= null && Contains(...)` and `== null` throw the actionable exception for a field with `IndexEmptyAndMissing = false`.
- `TestContainsOnFieldWithIndexEmptyAndMissingFalse` — confirms a plain `Contains` (no null guard) against such a field still serializes correctly.
- `TestContainsOnNullableSearchableStringWithSelectAndNotNull` — locks in the valid `-(ismissing(@String2)) (@String2:Fal)` serialization for a field that *is* indexed for missing values (default `IndexEmptyAndMissing = true`).

Added test model `ObjectWithNoMissingIndex` with a `[Searchable(IndexEmptyAndMissing = false)]` field to mirror the issue's configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)