### PR TITLE
Fix aggregation set boolean expression parsing

### DIFF
--- a/src/Redis.OM/Aggregation/AggregationPredicates/QueryPredicate.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/QueryPredicate.cs
@@ -53,6 +53,12 @@ namespace Redis.OM.Aggregation.AggregationPredicates
                 var memberExpression = binaryExpression.Left as MemberExpression;
                 if (memberExpression is null)
                 {
+                    if (binaryExpression.NodeType is ExpressionType.And or ExpressionType.AndAlso or ExpressionType.Or or ExpressionType.OrElse)
+                    {
+                        SplitBinaryExpression(binaryExpression, stack);
+                        return;
+                    }
+
                     if (binaryExpression.Left is UnaryExpression { NodeType: ExpressionType.Convert, Operand: MemberExpression } leftUnary)
                     {
                         memberExpression = (MemberExpression)leftUnary.Operand;
@@ -85,6 +91,12 @@ namespace Redis.OM.Aggregation.AggregationPredicates
                             var val = ExpressionParserUtilities.GetOperandString(mem);
                             stack.Push(BuildQueryPredicate(binaryExpression.NodeType, memberExpression, val));
                             break;
+                        default:
+                            var dialect = 1;
+                            var unaryValue = ExpressionParserUtilities.GetOperandStringForQueryArgs(uni, new List<object>(), ref dialect);
+                            PromoteDialect(dialect);
+                            stack.Push(BuildQueryPredicate(binaryExpression.NodeType, memberExpression, unaryValue));
+                            break;
                     }
                 }
                 else if (binaryExpression.Right is MemberExpression mem)
@@ -108,7 +120,13 @@ namespace Redis.OM.Aggregation.AggregationPredicates
             else if (expression is MethodCallExpression method)
             {
                 var dialect = 1;
-                stack.Push(ExpressionParserUtilities.TranslateMethodExpressions(method, new List<object>(), ref dialect));
+                var serialized = ExpressionParserUtilities.TranslateMethodExpressions(method, new List<object>(), ref dialect);
+                if (serialized.Contains("|") && !(serialized.StartsWith("(") && serialized.EndsWith(")")))
+                {
+                    serialized = $"({serialized})";
+                }
+
+                stack.Push(serialized);
                 PromoteDialect(dialect);
             }
             else if (expression is UnaryExpression uni)
@@ -187,13 +205,19 @@ namespace Redis.OM.Aggregation.AggregationPredicates
 
                 if (leftCall != null && rightCall != null)
                 {
-                    ValidateAndPushOperand(leftCall, stack);
+                    var leftStack = new Stack<string>();
+                    var rightStack = new Stack<string>();
+
+                    ValidateAndPushOperand(leftCall, leftStack);
+                    ValidateAndPushOperand(rightCall, rightStack);
+
+                    stack.Push(string.Join(" ", rightStack));
                     if (expression.NodeType == ExpressionType.Or || expression.NodeType == ExpressionType.OrElse)
                     {
                         stack.Push("|");
                     }
 
-                    ValidateAndPushOperand(rightCall, stack);
+                    stack.Push(string.Join(" ", leftStack));
                 }
                 else
                 {

--- a/src/Redis.OM/Aggregation/AggregationPredicates/QueryPredicate.cs
+++ b/src/Redis.OM/Aggregation/AggregationPredicates/QueryPredicate.cs
@@ -53,12 +53,6 @@ namespace Redis.OM.Aggregation.AggregationPredicates
                 var memberExpression = binaryExpression.Left as MemberExpression;
                 if (memberExpression is null)
                 {
-                    if (binaryExpression.NodeType is ExpressionType.And or ExpressionType.AndAlso or ExpressionType.Or or ExpressionType.OrElse)
-                    {
-                        SplitBinaryExpression(binaryExpression, stack);
-                        return;
-                    }
-
                     if (binaryExpression.Left is UnaryExpression { NodeType: ExpressionType.Convert, Operand: MemberExpression } leftUnary)
                     {
                         memberExpression = (MemberExpression)leftUnary.Operand;
@@ -198,30 +192,51 @@ namespace Redis.OM.Aggregation.AggregationPredicates
 
                 ValidateAndPushOperand(expression.Left, stack);
             }
+            else if (expression.NodeType is ExpressionType.And or ExpressionType.AndAlso or ExpressionType.Or or ExpressionType.OrElse)
+            {
+                // Connective node whose operands are neither connective binary expressions
+                // (handled by the branches above) nor simple comparisons (e.g. negated booleans
+                // or method calls such as Contains). Decompose each operand on its own stack and
+                // join them, wrapping an OR group in parentheses so it stays a single unit.
+                var leftStack = new Stack<string>();
+                var rightStack = new Stack<string>();
+
+                PushConnectiveOperand(expression.Left, leftStack);
+                PushConnectiveOperand(expression.Right, rightStack);
+
+                var isOr = expression.NodeType is ExpressionType.Or or ExpressionType.OrElse;
+                if (isOr)
+                {
+                    stack.Push(")");
+                }
+
+                stack.Push(string.Join(" ", rightStack));
+                if (isOr)
+                {
+                    stack.Push("|");
+                }
+
+                stack.Push(string.Join(" ", leftStack));
+                if (isOr)
+                {
+                    stack.Push("(");
+                }
+            }
             else
             {
-                var leftCall = expression.Left as MethodCallExpression;
-                var rightCall = expression.Right as MethodCallExpression;
+                ValidateAndPushOperand(expression, stack);
+            }
 
-                if (leftCall != null && rightCall != null)
+            void PushConnectiveOperand(Expression operand, Stack<string> operandStack)
+            {
+                if (operand is BinaryExpression be
+                    && be.NodeType is ExpressionType.And or ExpressionType.AndAlso or ExpressionType.Or or ExpressionType.OrElse)
                 {
-                    var leftStack = new Stack<string>();
-                    var rightStack = new Stack<string>();
-
-                    ValidateAndPushOperand(leftCall, leftStack);
-                    ValidateAndPushOperand(rightCall, rightStack);
-
-                    stack.Push(string.Join(" ", rightStack));
-                    if (expression.NodeType == ExpressionType.Or || expression.NodeType == ExpressionType.OrElse)
-                    {
-                        stack.Push("|");
-                    }
-
-                    stack.Push(string.Join(" ", leftStack));
+                    SplitBinaryExpression(be, operandStack);
                 }
                 else
                 {
-                    ValidateAndPushOperand(expression, stack);
+                    ValidateAndPushOperand(operand, operandStack);
                 }
             }
         }

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -46,7 +46,9 @@ namespace Redis.OM.Common
                     $"@{((ConstantExpression)method.Arguments[0]).Value}",
                 MethodCallExpression method => GetOperandString(method),
                 UnaryExpression unary => GetOperandString(unary.Operand),
-                BinaryExpression binExpression => ParseBinaryExpression(binExpression, filterFormat),
+                BinaryExpression binExpression => TryEvaluateBinaryExpression(binExpression, out var evaluated)
+                    ? ValueToString(evaluated!)
+                    : ParseBinaryExpression(binExpression, filterFormat),
                 LambdaExpression lambda => GetOperandString(lambda.Body),
                 _ => string.Empty
             };
@@ -88,6 +90,9 @@ namespace Redis.OM.Common
                 ConstantExpression constExp => ValueToString(constExp.Value),
                 MemberExpression member => GetOperandStringForMember(member, treatEnumsAsInt, negate: negate, treatBooleanMemberAsUnary: treatBooleanMemberAsUnary),
                 MethodCallExpression method => TranslateMethodStandardQuerySyntax(method, parameters, ref dialectNeeded),
+                BinaryExpression binExpression => TryEvaluateBinaryExpression(binExpression, out var evaluated)
+                    ? ValueToString(evaluated!)
+                    : ParseBinaryExpression(binExpression),
                 UnaryExpression unary => GetOperandStringForQueryArgs(unary.Operand, parameters, ref dialectNeeded, treatEnumsAsInt, unary.NodeType == ExpressionType.Not, treatBooleanMemberAsUnary: treatBooleanMemberAsUnary),
                 _ => throw new ArgumentException("Unrecognized Expression type")
             };
@@ -1108,6 +1113,33 @@ namespace Redis.OM.Common
             };
         }
 
+        private static bool TryEvaluateBinaryExpression(BinaryExpression expression, out object? value)
+        {
+            if (ContainsParameterExpression(expression))
+            {
+                value = null;
+                return false;
+            }
+
+            try
+            {
+                value = Expression.Lambda(expression).Compile().DynamicInvoke();
+                return true;
+            }
+            catch
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        private static bool ContainsParameterExpression(Expression expression)
+        {
+            var foundParameter = false;
+            new ParameterExpressionFinder(() => foundParameter = true).Visit(expression);
+            return foundParameter;
+        }
+
         private static string TranslateVectorRange(MethodCallExpression exp, List<object> parameters)
         {
             if (exp.Arguments[0] is not MemberExpression member)
@@ -1150,6 +1182,22 @@ namespace Redis.OM.Common
             }
 
             return $"{field}:[VECTOR_RANGE ${distanceArgName} ${vectorArgName}]";
+        }
+
+        private sealed class ParameterExpressionFinder : ExpressionVisitor
+        {
+            private readonly Action _onParameter;
+
+            public ParameterExpressionFinder(Action onParameter)
+            {
+                _onParameter = onParameter;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                _onParameter();
+                return node;
+            }
         }
     }
 }

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -46,9 +46,7 @@ namespace Redis.OM.Common
                     $"@{((ConstantExpression)method.Arguments[0]).Value}",
                 MethodCallExpression method => GetOperandString(method),
                 UnaryExpression unary => GetOperandString(unary.Operand),
-                BinaryExpression binExpression => TryEvaluateBinaryExpression(binExpression, out var evaluated)
-                    ? ValueToString(evaluated!)
-                    : ParseBinaryExpression(binExpression, filterFormat),
+                BinaryExpression binExpression => ParseBinaryExpression(binExpression, filterFormat),
                 LambdaExpression lambda => GetOperandString(lambda.Body),
                 _ => string.Empty
             };

--- a/src/Redis.OM/Common/ExpressionParserUtilities.cs
+++ b/src/Redis.OM/Common/ExpressionParserUtilities.cs
@@ -90,7 +90,7 @@ namespace Redis.OM.Common
                 MethodCallExpression method => TranslateMethodStandardQuerySyntax(method, parameters, ref dialectNeeded),
                 BinaryExpression binExpression => TryEvaluateBinaryExpression(binExpression, out var evaluated)
                     ? ValueToString(evaluated!)
-                    : ParseBinaryExpression(binExpression),
+                    : throw new ArgumentException($"Could not translate the expression '{binExpression}' into a query operand. Arithmetic over indexed fields (e.g. 'x.Field + 2') is not supported inside a query predicate; only expressions that resolve to a constant value can be used."),
                 UnaryExpression unary => GetOperandStringForQueryArgs(unary.Operand, parameters, ref dialectNeeded, treatEnumsAsInt, unary.NodeType == ExpressionType.Not, treatBooleanMemberAsUnary: treatBooleanMemberAsUnary),
                 _ => throw new ArgumentException("Unrecognized Expression type")
             };

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -535,6 +535,35 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _ = collection.Where(query).ToList();
             _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] ( @Age:[2 2] | @Age:[50 50] ) )", "WITHCURSOR", "COUNT", "10000");
         }
+
+        [Fact]
+        public void RightBinExpressionOperatorWithContainsArrayValues()
+        {
+            var collection = new RedisAggregationSet<Person>(_substitute, true, chunkSize: 10000);
+            _substitute.Execute("FT.AGGREGATE", Arg.Any<object[]>()).Returns(MockedResult);
+            _substitute.Execute("FT.CURSOR", Arg.Any<object[]>()).Returns(MockedResultCursorEnd);
+
+            double?[] heights1 = new double?[] { 170, 171 };
+            double?[] heights2 = new double?[] { 180, 181 };
+            Expression<Func<AggregationResult<Person>, bool>> query = a => a.RecordShell!.Age == 0 && (heights1.Contains(a.RecordShell!.Height) || heights2.Contains(a.RecordShell.Height));
+
+            _ = collection.Where(query).ToList();
+            _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] (@Height:[170 170]|@Height:[171 171]) | (@Height:[180 180]|@Height:[181 181]) )", "WITHCURSOR", "COUNT", "10000");
+        }
+
+        [Fact]
+        public void RightBinExpressionOperatorWithCapturedValues()
+        {
+            var collection = new RedisAggregationSet<Person>(_substitute, true, chunkSize: 10000);
+            _substitute.Execute("FT.AGGREGATE", Arg.Any<object[]>()).Returns(MockedResult);
+            _substitute.Execute("FT.CURSOR", Arg.Any<object[]>()).Returns(MockedResultCursorEnd);
+
+            var age = 0;
+            Expression<Func<AggregationResult<Person>, bool>> query = a => a.RecordShell!.Age == age && (a.RecordShell!.Age == age + 2 || a.RecordShell!.Age == age + 50);
+
+            _ = collection.Where(query).ToList();
+            _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] ( @Age:[2 2] | @Age:[50 50] ) )", "WITHCURSOR", "COUNT", "10000");
+        }
         
         [Fact]
         public void RightBinExpressionWithUniaryOperator()

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -548,7 +548,7 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             Expression<Func<AggregationResult<Person>, bool>> query = a => a.RecordShell!.Age == 0 && (heights1.Contains(a.RecordShell!.Height) || heights2.Contains(a.RecordShell.Height));
 
             _ = collection.Where(query).ToList();
-            _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] (@Height:[170 170]|@Height:[171 171]) | (@Height:[180 180]|@Height:[181 181]) )", "WITHCURSOR", "COUNT", "10000");
+            _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] ( (@Height:[170 170]|@Height:[171 171]) | (@Height:[180 180]|@Height:[181 181]) ) )", "WITHCURSOR", "COUNT", "10000");
         }
 
         [Fact]
@@ -565,6 +565,23 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] ( @Age:[2 2] | @Age:[50 50] ) )", "WITHCURSOR", "COUNT", "10000");
         }
         
+        [Fact]
+        public void ConnectiveExpressionWithNegatedOperands()
+        {
+            var collection = new RedisAggregationSet<Person>(_substitute, true, chunkSize: 10000);
+            _substitute.Execute("FT.AGGREGATE", Arg.Any<object[]>()).Returns(MockedResult);
+            _substitute.Execute("FT.CURSOR", Arg.Any<object[]>()).Returns(MockedResultCursorEnd);
+
+            // Both operands of the OR are UnaryExpressions (negated method calls), which are
+            // neither connective binary expressions nor simple comparisons. This previously
+            // recursed indefinitely between SplitBinaryExpression and ValidateAndPushOperand,
+            // throwing a StackOverflowException.
+            Expression<Func<AggregationResult<Person>, bool>> query = a => !a.RecordShell!.Name.Contains("Steve") || !a.RecordShell!.Name.Contains("Bob");
+
+            _ = collection.Where(query).ToList();
+            _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( (-((@Name:Steve))) | (-((@Name:Bob))) )", "WITHCURSOR", "COUNT", "10000");
+        }
+
         [Fact]
         public void RightBinExpressionWithUniaryOperator()
         {

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/AggregationSetTests.cs
@@ -564,7 +564,21 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
             _ = collection.Where(query).ToList();
             _substitute.Received().Execute("FT.AGGREGATE", "person-idx", "( @Age:[0 0] ( @Age:[2 2] | @Age:[50 50] ) )", "WITHCURSOR", "COUNT", "10000");
         }
-        
+
+        [Fact]
+        public void RightBinExpressionOperatorWithFieldArithmeticThrows()
+        {
+            var collection = new RedisAggregationSet<Person>(_substitute, true, chunkSize: 10000);
+            _substitute.Execute("FT.AGGREGATE", Arg.Any<object[]>()).Returns(MockedResult);
+            _substitute.Execute("FT.CURSOR", Arg.Any<object[]>()).Returns(MockedResultCursorEnd);
+
+            // Arithmetic over an indexed field cannot be resolved to a constant query operand.
+            // This must fail loudly rather than emit invalid APPLY-style arithmetic into the query.
+            Expression<Func<AggregationResult<Person>, bool>> query = a => a.RecordShell!.Age == a.RecordShell!.Height + 2;
+
+            Assert.Throws<ArgumentException>(() => collection.Where(query).ToList());
+        }
+
         [Fact]
         public void ConnectiveExpressionWithNegatedOperands()
         {


### PR DESCRIPTION
Issue: #416

Root cause: `QueryPredicate` only handled a narrow set of binary operand shapes, and `Contains`/captured arithmetic cases could fall through to an invalid-expression path or lose the right-hand operand.

Fix: broaden the aggregation predicate serializer to recurse through connective binary expressions, evaluate closed arithmetic expressions to constants, and preserve grouped `Contains` operands in the final query string.

Tests run:
- `dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --filter "RightBinExpressionOperatorWithContainsArrayValues|RightBinExpressionOperatorWithCapturedValues"`
- `dotnet test test/Redis.OM.Unit.Tests/Redis.OM.Unit.Tests.csproj --filter "RightBinExpressionOperator|RightBinExpressionWithUniaryOperator|LeftBinExpressionWithUniaryOperator|RightBinExpressionOperatorWithContainsArrayValues|RightBinExpressionOperatorWithCapturedValues"`

Remaining risk: this stays scoped to the aggregation boolean/query serializer path; I did not run the full unit suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core expression-to-query serialization for aggregation filters; incorrect grouping could alter query semantics, though behavior is covered by new targeted tests and the full suite was not run per the PR description.
> 
> **Overview**
> Fixes aggregation `Where` boolean expression translation so complex LINQ predicates serialize to valid RediSearch query strings instead of failing, looping, or dropping operands.
> 
> **`QueryPredicate`** now handles connective nodes whose children are not simple comparisons (e.g. negated `Contains`, mixed `&&`/`||` with method calls): each side is built on its own stack and OR groups get parentheses. Method-call results that contain `|` are wrapped when needed. Unary comparison right-hand sides fall through to `GetOperandStringForQueryArgs` instead of being unsupported.
> 
> **`ExpressionParserUtilities`** evaluates closed-over binary arithmetic to constants for query operands and throws a clear `ArgumentException` when arithmetic involves indexed fields (e.g. `Age == Height + 2`).
> 
> New unit tests lock expected `FT.AGGREGATE` filter strings for `Contains` on captured arrays, captured `age + N`, negated OR, and the field-arithmetic error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a385b4991676bc937d31d19587acd9eeece78a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->