### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
+++ b/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.AllMiniLML6V2</RootNamespace>
-        <PackageVersion>1.1.0</PackageVersion>
-        <Version>1.1.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.1.0</PackageReleaseNotes>
+        <PackageVersion>1.2.0</PackageVersion>
+        <Version>1.2.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
         <Description>Sentence Vectorizer for Redis OM .NET using all-MiniLM-L6-v2</Description>
         <Title>Redis OM all-MiniLM-L6-v2 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
+++ b/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
@@ -4,9 +4,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.Resnet18</RootNamespace>
-        <PackageVersion>1.1.0</PackageVersion>
-        <Version>1.1.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.1.0</PackageReleaseNotes>
+        <PackageVersion>1.2.0</PackageVersion>
+        <Version>1.2.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
         <Description>Resnet 18 Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Resnet 18 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
+++ b/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM</RootNamespace>
-        <PackageVersion>1.1.0</PackageVersion>
-        <Version>1.1.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.1.0</PackageReleaseNotes>
+        <PackageVersion>1.2.0</PackageVersion>
+        <Version>1.2.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
         <Description>Core Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>1.1.0</PackageVersion>
-    <Version>1.1.0</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.1.0</PackageReleaseNotes>
+    <PackageVersion>1.2.0</PackageVersion>
+    <Version>1.2.0</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>


### PR DESCRIPTION
Bumps the package version from `1.1.0` to `1.2.0` across all four packable projects:

- `Redis.OM`
- `Redis.OM.Vectorizers`
- `Redis.OM.Vectorizers.AllMiniLML6V2`
- `Redis.OM.Vectorizers.Resnet18`

Each `PackageVersion`, `Version`, and the `PackageReleaseNotes` URL tag is updated to `v1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only changes with no runtime or API code modifications.
> 
> **Overview**
> Bumps published NuGet package metadata from **1.1.0** to **1.2.0** in all four packable projects: `Redis.OM`, `Redis.OM.Vectorizers`, `Redis.OM.Vectorizers.AllMiniLML6V2`, and `Redis.OM.Vectorizers.Resnet18`.
> 
> Each project updates `PackageVersion`, `Version`, and `PackageReleaseNotes` to point at the **v1.2.0** GitHub release. No application or library source changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dcd1f9db1b7eee4726cd175fdd3ffaf5da87356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->