### PR TITLE
Fix RESP3 map parsing for FT.SEARCH/AGGREGATE/INFO (#570)

### DIFF
--- a/src/Redis.OM/Aggregation/AggregationResult.cs
+++ b/src/Redis.OM/Aggregation/AggregationResult.cs
@@ -72,7 +72,7 @@ namespace Redis.OM.Aggregation
         /// <returns>A set of Aggregation Results.</returns>
         internal static IEnumerable<AggregationResult<T>> FromRedisResult(RedisReply res)
         {
-            var arr = res.ToArray();
+            var arr = AggregationResult.NormalizeReply(res);
             for (var i = 1; i < arr.Length; i++)
             {
                 yield return new AggregationResult<T>(arr[i]);
@@ -117,11 +117,40 @@ namespace Redis.OM.Aggregation
         /// <returns>an enumerable of results.</returns>
         public static IEnumerable<AggregationResult> FromRedisResult(RedisReply res)
         {
-            var arr = res.ToArray();
+            var arr = NormalizeReply(res);
             for (var i = 1; i < arr.Length; i++)
             {
                 yield return new AggregationResult(arr[i]);
             }
+        }
+
+        /// <summary>
+        /// Normalizes an aggregation reply into the flat RESP2 layout the parsers expect. RESP2 replies
+        /// are returned unchanged; a RESP3 map reply (negotiated automatically by newer
+        /// StackExchange.Redis versions) is reshaped from its <c>total_results</c>/<c>results</c>
+        /// structure into the legacy <c>[count, fields, ...]</c> array, where each <c>fields</c> entry is
+        /// the result's <c>extra_attributes</c> map.
+        /// </summary>
+        /// <param name="res">The raw aggregation reply.</param>
+        /// <returns>The reply in flat RESP2 layout.</returns>
+        internal static RedisReply[] NormalizeReply(RedisReply res)
+        {
+            if (!res.IsMap)
+            {
+                return res.ToArray();
+            }
+
+            var flattened = new List<RedisReply> { res.GetMapValueOrDefault("total_results") ?? 0L };
+            var results = res.GetMapValueOrDefault("results");
+            if (results is not null)
+            {
+                foreach (var result in results.ToArray())
+                {
+                    flattened.Add(result.GetMapValueOrDefault("extra_attributes") ?? new RedisReply(Array.Empty<RedisReply>()));
+                }
+            }
+
+            return flattened.ToArray();
         }
     }
 }

--- a/src/Redis.OM/RedisIndexInfo.cs
+++ b/src/Redis.OM/RedisIndexInfo.cs
@@ -292,20 +292,35 @@ namespace Redis.OM
                         case "M": M = value; break;
                         case "ef_construction": EfConstruction = value; break;
                         case "WEIGHT": Weight = value; break;
-                        case "INDEXMISSING": IndexMissing = true; break;
-                        case "INDEXEMPTY": IndexEmpty = true; break;
                     }
                 }
 
-                if (responseArray.Any(x => ((string)x).Equals("NOSTEM", StringComparison.InvariantCultureIgnoreCase)))
+                // Boolean flags are emitted as trailing top-level tokens under RESP2, but grouped
+                // inside a nested "flags" array under RESP3. Flattening one level yields the leaf
+                // tokens for either layout so the flag detection below is protocol-agnostic.
+                var flagTokens = responseArray
+                    .SelectMany(x => x.ToArray())
+                    .Select(x => x.ToString(CultureInfo.InvariantCulture))
+                    .ToArray();
+
+                if (flagTokens.Any(x => x.Equals("NOSTEM", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     NoStem = true;
                 }
 
-                if (responseArray.Select(x => x.ToString())
-                    .Any(x => x.Equals("SORTABLE", StringComparison.InvariantCultureIgnoreCase)))
+                if (flagTokens.Any(x => x.Equals("SORTABLE", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     Sortable = true;
+                }
+
+                if (flagTokens.Any(x => x.Equals("INDEXMISSING", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    IndexMissing = true;
+                }
+
+                if (flagTokens.Any(x => x.Equals("INDEXEMPTY", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    IndexEmpty = true;
                 }
             }
 

--- a/src/Redis.OM/RedisReply.cs
+++ b/src/Redis.OM/RedisReply.cs
@@ -44,6 +44,13 @@ namespace Redis.OM
                     _values = ((RedisResult[])result!).Select(x => new RedisReply(x)).ToArray();
                     break;
             }
+
+            // When the connection negotiates RESP3, commands such as FT.SEARCH and FT.AGGREGATE
+            // reply with a map rather than the flat RESP2 array. SE.Redis collapses a map's
+            // Resp2Type to Array (the flattened, interleaved key/value pairs handled above), so the
+            // existing array-based parsing is preserved. We additionally record that the node was a
+            // map so response parsers can opt into the RESP3 shape via <see cref="IsMap"/>.
+            IsMap = result.Resp3Type == ResultType.Map;
         }
 
         /// <summary>
@@ -101,9 +108,28 @@ namespace Redis.OM
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="RedisReply"/> class representing a RESP3 map,
+        /// stored as a flattened, interleaved key/value array. Used to exercise the RESP3 parsing paths.
+        /// </summary>
+        /// <param name="values">the flattened key/value pairs.</param>
+        /// <param name="isMap">whether the reply represents a RESP3 map.</param>
+        internal RedisReply(RedisReply[] values, bool isMap)
+        {
+            _values = values;
+            IsMap = isMap;
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the result represents an error.
         /// </summary>
         public bool Error { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the reply was a RESP3 map (e.g. a RESP3 FT.SEARCH or
+        /// FT.AGGREGATE response). The underlying values are still exposed as the flattened,
+        /// interleaved key/value array via <see cref="ToArray"/>.
+        /// </summary>
+        internal bool IsMap { get; }
 
         /// <summary>
         /// implicitly converts the reply to a double.
@@ -507,6 +533,30 @@ namespace Redis.OM
             }
 
             throw new InvalidCastException();
+        }
+
+        /// <summary>
+        /// Looks up a value by key, treating this reply as a RESP3 map whose values are stored as a
+        /// flattened, interleaved key/value array.
+        /// </summary>
+        /// <param name="key">The map key to look up.</param>
+        /// <returns>The value associated with <paramref name="key"/>, or <c>null</c> if absent.</returns>
+        internal RedisReply? GetMapValueOrDefault(string key)
+        {
+            if (_values is null)
+            {
+                return null;
+            }
+
+            for (var i = 0; i + 1 < _values.Length; i += 2)
+            {
+                if ((string)_values[i] == key)
+                {
+                    return _values[i + 1];
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Redis.OM/RedisUriParser.cs
+++ b/src/Redis.OM/RedisUriParser.cs
@@ -26,6 +26,7 @@ namespace Redis.OM
             if (string.IsNullOrEmpty(uriString))
             {
                 options.EndPoints.Add("localhost:6379");
+                ParseProtocol(options, null);
                 return options;
             }
 
@@ -33,10 +34,50 @@ namespace Redis.OM
             ParseHost(options, uri);
             ParseUserInfo(options, uri);
             ParseQueryArguments(options, uri);
+            ParseProtocol(options, uri);
             ParseDefaultDatabase(options, uri);
             options.Ssl = uri.Scheme == "rediss";
             options.AbortOnConnectFail = false;
             return options;
+        }
+
+        /// <summary>
+        /// Resolves the RESP protocol to negotiate. An explicit <c>protocol</c> query argument
+        /// (<c>resp2</c>/<c>resp3</c> or <c>2</c>/<c>3</c>) takes precedence; otherwise the
+        /// <c>REDIS_OM_PROTOCOL</c> environment variable is used as a fallback default. When neither is
+        /// supplied the StackExchange.Redis default is left untouched.
+        /// </summary>
+        /// <param name="options">The configuration options to populate.</param>
+        /// <param name="uri">The parsed URI, or <c>null</c> when none was supplied.</param>
+        private static void ParseProtocol(ConfigurationOptions options, Uri? uri)
+        {
+            string? requested = null;
+            if (uri is not null && !string.IsNullOrEmpty(uri.Query))
+            {
+                requested = ParseQuery(uri.Query.Substring(1))
+                    .Where(x => x.Key.ToLower() == "protocol")
+                    .Select(x => x.Value)
+                    .FirstOrDefault();
+            }
+
+            requested ??= Environment.GetEnvironmentVariable("REDIS_OM_PROTOCOL");
+
+            if (string.IsNullOrEmpty(requested))
+            {
+                return;
+            }
+
+            switch (requested!.Trim().ToLowerInvariant())
+            {
+                case "2":
+                case "resp2":
+                    options.Protocol = RedisProtocol.Resp2;
+                    break;
+                case "3":
+                case "resp3":
+                    options.Protocol = RedisProtocol.Resp3;
+                    break;
+            }
         }
 
         private static void ParseDefaultDatabase(ConfigurationOptions options, Uri uri)

--- a/src/Redis.OM/Searching/SearchResponse.cs
+++ b/src/Redis.OM/Searching/SearchResponse.cs
@@ -15,7 +15,7 @@ namespace Redis.OM.Searching
         /// <param name="val">The redis response.</param>
         public SearchResponse(RedisReply val)
         {
-            var vals = val.ToArray();
+            var vals = NormalizeReply(val);
             DocumentCount = vals[0];
             Documents = new Dictionary<string, IDictionary<string, string>>();
             Scores = new Dictionary<string, double>();
@@ -78,6 +78,44 @@ namespace Redis.OM.Searching
             }
 
             return dict;
+        }
+
+        /// <summary>
+        /// Normalizes a search reply into the flat RESP2 layout the parsers expect. RESP2 replies are
+        /// returned unchanged; a RESP3 map reply (negotiated automatically by newer StackExchange.Redis
+        /// versions) is reshaped from its <c>total_results</c>/<c>results</c> structure into the legacy
+        /// <c>[count, id, (score,) fields, ...]</c> array.
+        /// </summary>
+        /// <param name="val">The raw search reply.</param>
+        /// <returns>The reply in flat RESP2 layout.</returns>
+        internal static RedisReply[] NormalizeReply(RedisReply val)
+        {
+            if (!val.IsMap)
+            {
+                return val.ToArray();
+            }
+
+            var flattened = new List<RedisReply> { val.GetMapValueOrDefault("total_results") ?? 0L };
+            var results = val.GetMapValueOrDefault("results");
+            if (results is not null)
+            {
+                foreach (var result in results.ToArray())
+                {
+                    flattened.Add(result.GetMapValueOrDefault("id") ?? string.Empty);
+
+                    // WITHSCORES surfaces the score as a scalar map entry; the existing parser treats it
+                    // as the metadata sitting between the id and the field payload.
+                    var score = result.GetMapValueOrDefault("score");
+                    if (score is not null)
+                    {
+                        flattened.Add(score);
+                    }
+
+                    flattened.Add(result.GetMapValueOrDefault("extra_attributes") ?? new RedisReply(Array.Empty<RedisReply>()));
+                }
+            }
+
+            return flattened.ToArray();
         }
 
         /// <summary>
@@ -154,7 +192,7 @@ namespace Redis.OM.Searching
             }
             else
             {
-                var vals = val.ToArray();
+                var vals = SearchResponse.NormalizeReply(val);
                 if (vals.Length == 1)
                 {
                     var str = vals[0].ToString();
@@ -248,7 +286,7 @@ namespace Redis.OM.Searching
 
         private static SearchResponse<T> PrimitiveSearchResponse(RedisReply redisReply)
         {
-            var arr = redisReply.ToArray();
+            var arr = SearchResponse.NormalizeReply(redisReply);
             var response = new SearchResponse<T>();
             response.DocumentCount = arr[0];
             for (var i = 1; i < arr.Count();)

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/Resp3ResponseTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/Resp3ResponseTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Redis.OM;
+using Redis.OM.Aggregation;
+using Redis.OM.Searching;
+using Xunit;
+
+namespace Redis.OM.Unit.Tests.RediSearchTests
+{
+    /// <summary>
+    /// Covers parsing of RESP3 map-shaped replies for FT.SEARCH and FT.AGGREGATE. Newer
+    /// StackExchange.Redis versions negotiate RESP3 automatically, which changes the reply from the
+    /// flat RESP2 array into a map keyed by total_results/results - the cause of issue #570
+    /// (InvalidCastException "Could not cast to long").
+    /// </summary>
+    public class Resp3ResponseTests
+    {
+        private static RedisReply EmptyArray => new(Array.Empty<RedisReply>());
+
+        [Fact]
+        public void Search_Resp3Map_ParsesDocuments()
+        {
+            var reply = SearchMap(new[]
+            {
+                Result("hash-person-idx:1", score: null, "Id", "1", "Name", "Steve"),
+                Result("hash-person-idx:2", score: null, "Id", "2", "Name", "Alice"),
+            });
+
+            var response = new SearchResponse<HashPerson>(reply);
+
+            Assert.Equal(2, response.DocumentCount);
+            Assert.Equal(2, response.Documents.Count);
+            Assert.Equal("Steve", response["hash-person-idx:1"].Name);
+            Assert.Equal("Alice", response["hash-person-idx:2"].Name);
+            Assert.Empty(response.Scores);
+        }
+
+        [Fact]
+        public void Search_Resp3Map_WithScores_PopulatesScores()
+        {
+            var reply = SearchMap(new[]
+            {
+                Result("hash-person-idx:1", score: "0.5", "Id", "1", "Name", "Steve"),
+                Result("hash-person-idx:2", score: "12", "Id", "2", "Name", "Alice"),
+            });
+
+            var response = new SearchResponse<HashPerson>(reply);
+
+            Assert.Equal(2, response.Documents.Count);
+            Assert.Equal("Steve", response["hash-person-idx:1"].Name);
+            Assert.Equal(0.5, response.Scores["hash-person-idx:1"]);
+            Assert.Equal(12, response.Scores["hash-person-idx:2"]);
+        }
+
+        [Fact]
+        public void Search_Resp3Map_NonGeneric_ParsesDocumentsAndScores()
+        {
+            var reply = SearchMap(new[]
+            {
+                Result("hash-person-idx:1", score: "38", "Id", "1", "Name", "Steve"),
+            });
+
+            var response = new SearchResponse(reply);
+
+            Assert.Single(response.Documents);
+            Assert.Equal("Steve", response.Documents["hash-person-idx:1"]["Name"]);
+            Assert.Equal(38, response.Scores["hash-person-idx:1"]);
+        }
+
+        [Fact]
+        public void Search_Resp3Map_EmptyResults_YieldsZeroCount()
+        {
+            var reply = SearchMap(Array.Empty<RedisReply>());
+
+            var response = new SearchResponse<HashPerson>(reply);
+
+            Assert.Equal(0, response.DocumentCount);
+            Assert.Empty(response.Documents);
+        }
+
+        [Fact]
+        public void Aggregation_Resp3Map_ParsesRows()
+        {
+            var reply = AggregationMap(new[]
+            {
+                Map(("type", (RedisReply)"a"), ("cnt", (RedisReply)"3")),
+                Map(("type", (RedisReply)"b"), ("cnt", (RedisReply)"5")),
+            });
+
+            var results = AggregationResult.FromRedisResult(reply).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Equal("a", results[0]["type"].ToString());
+            Assert.Equal(3, (int)results[0]["cnt"]);
+            Assert.Equal("b", results[1]["type"].ToString());
+            Assert.Equal(5, (int)results[1]["cnt"]);
+        }
+
+        private static RedisReply Map(params (string Key, RedisReply Value)[] entries)
+        {
+            var flattened = new List<RedisReply>();
+            foreach (var (key, value) in entries)
+            {
+                flattened.Add(key);
+                flattened.Add(value);
+            }
+
+            return new RedisReply(flattened.ToArray(), isMap: true);
+        }
+
+        private static RedisReply Result(string id, string? score, params string[] fields)
+        {
+            var entries = new List<(string, RedisReply)> { ("id", id) };
+            if (score is not null)
+            {
+                entries.Add(("score", score));
+            }
+
+            var fieldReplies = fields.Select(f => (RedisReply)f).ToArray();
+            entries.Add(("extra_attributes", new RedisReply(fieldReplies, isMap: true)));
+            entries.Add(("values", EmptyArray));
+            return Map(entries.ToArray());
+        }
+
+        private static RedisReply SearchMap(RedisReply[] results) => Map(
+            ("attributes", EmptyArray),
+            ("format", "STRING"),
+            ("results", new RedisReply(results)),
+            ("total_results", new RedisReply((long)results.Length)),
+            ("warning", EmptyArray));
+
+        private static RedisReply AggregationMap(RedisReply[] rows)
+        {
+            var results = rows.Select(r => Map(("extra_attributes", r), ("values", EmptyArray))).ToArray();
+            return Map(
+                ("attributes", EmptyArray),
+                ("format", "STRING"),
+                ("results", new RedisReply(results)),
+                ("total_results", new RedisReply((long)rows.Length)),
+                ("warning", EmptyArray));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #570. After StackExchange.Redis auto-negotiates **RESP3** (the default against RESP3-capable servers in newer SE.Redis versions), `RedisCollection<T>.ToListAsync()` and other searches throw:

```
System.InvalidCastException: Could not cast to long
   at Redis.OM.RedisReply.op_Implicit(RedisReply v)
   at Redis.OM.Searching.SearchResponse`1..ctor(RedisReply val)
   ...
```

Under RESP3, `FT.SEARCH`/`FT.AGGREGATE`/`FT.INFO` reply with a **map** (`total_results`/`results`/`extra_attributes`) instead of the flat RESP2 array. SE.Redis collapses a map's `Resp2Type` to `Array` (flattened, interleaved key/value pairs), so the existing parsers read the first map key (`"attributes"`) as the document count and fail to cast it to `long`. Forcing `Protocol = RedisProtocol.Resp2` is the current workaround.

## Fix

Detect the RESP3 map shape at the parser layer and reshape it back into the legacy RESP2 layout, so the existing parse logic runs unchanged:

- **`RedisReply`** records `IsMap` (`Resp3Type == ResultType.Map`) and exposes `GetMapValueOrDefault(key)`. The existing flattening behavior is preserved — `IsMap` is purely additive.
- **`SearchResponse.NormalizeReply`** reshapes a map reply into the legacy `[count, id, (score,) fields, …]` array (used by both `SearchResponse` and `SearchResponse<T>`, including WITHSCORES).
- **`AggregationResult.NormalizeReply`** does the same for `FT.AGGREGATE` (generic + non-generic, incl. WITHCURSOR).
- **`RedisIndexInfoAttribute`** — RESP3 groups attribute flags (`SORTABLE`/`NOSTEM`/`INDEXMISSING`/`INDEXEMPTY`) inside a nested `flags` array rather than as trailing top-level tokens; flag detection now flattens one level so both protocols are handled.
- **`RedisUriParser`** honors a `protocol` URI query arg (`resp2`/`resp3` or `2`/`3`) and the `REDIS_OM_PROTOCOL` environment variable. This gives users an explicit protocol selector (and a RESP2 workaround) and lets the whole test suite run under RESP3.

## Testing

- Adds `Resp3ResponseTests` — deterministic unit tests that feed synthetic RESP3 map replies through the search and aggregation parsers. These guard the fix in CI, which runs RESP2 by default.
- Ran the full integration suite under **both** protocols (net6.0, parallelization disabled, against `redis/redis-stack-server`):
  - RESP2 baseline: **637/0**
  - `REDIS_OM_PROTOCOL=resp3`: **637/0**

## Notes

- RESP3 reports query timeouts in the map's `warning` field rather than as a single-element array, so the existing `TimeoutException` detection path doesn't trigger under RESP3. Left out of scope for this fix; can follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RediSearch response parsing on a widely used path, but RESP2 behavior is preserved and the fix is covered by new unit tests plus full integration runs under both protocols.
> 
> **Overview**
> Fixes **#570** by teaching RediSearch response parsers to handle **RESP3 map-shaped** replies when StackExchange.Redis negotiates RESP3 automatically.
> 
> **`RedisReply`** now records **`IsMap`** (`Resp3Type == Map`) and adds **`GetMapValueOrDefault`** for flattened key/value map access, without changing existing array flattening behavior.
> 
> **`SearchResponse.NormalizeReply`** and **`AggregationResult.NormalizeReply`** detect map replies and reshape `total_results` / `results` / `extra_attributes` (and search **`score`** when present) back into the legacy flat RESP2 arrays so existing parse logic stays unchanged.
> 
> **`RedisIndexInfoAttribute`** no longer treats `INDEXMISSING` / `INDEXEMPTY` as inline switch cases; it flattens one level so **`NOSTEM`**, **`SORTABLE`**, **`INDEXMISSING`**, and **`INDEXEMPTY`** work whether flags are top-level (RESP2) or nested under **`flags`** (RESP3).
> 
> **`RedisUriParser`** sets **`ConfigurationOptions.Protocol`** from a `protocol` URI query (`resp2`/`resp3` or `2`/`3`) or **`REDIS_OM_PROTOCOL`**, leaving SE.Redis defaults when unset.
> 
> Adds **`Resp3ResponseTests`** with synthetic RESP3 map replies for search (with/without scores) and aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f57064f49fff20471792ab8e8b64142e6bb9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->