### PR TITLE
Bump package versions to 1.3.0

### DIFF
--- a/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
+++ b/src/Redis.OM.Vectorizers.AllMiniLML6V2/Redis.OM.Vectorizers.AllMiniLML6V2.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.AllMiniLML6V2</RootNamespace>
-        <PackageVersion>1.2.0</PackageVersion>
-        <Version>1.2.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
+        <PackageVersion>1.3.0</PackageVersion>
+        <Version>1.3.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.3.0</PackageReleaseNotes>
         <Description>Sentence Vectorizer for Redis OM .NET using all-MiniLM-L6-v2</Description>
         <Title>Redis OM all-MiniLM-L6-v2 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
+++ b/src/Redis.OM.Vectorizers.Resnet18/Redis.OM.Vectorizers.Resnet18.csproj
@@ -4,9 +4,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM.Vectorizers.Resnet18</RootNamespace>
-        <PackageVersion>1.2.0</PackageVersion>
-        <Version>1.2.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
+        <PackageVersion>1.3.0</PackageVersion>
+        <Version>1.3.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.3.0</PackageReleaseNotes>
         <Description>Resnet 18 Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Resnet 18 Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
+++ b/src/Redis.OM.Vectorizers/Redis.OM.Vectorizers.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Redis.OM</RootNamespace>
-        <PackageVersion>1.2.0</PackageVersion>
-        <Version>1.2.0</Version>
-        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
+        <PackageVersion>1.3.0</PackageVersion>
+        <Version>1.3.0</Version>
+        <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.3.0</PackageReleaseNotes>
         <Description>Core Vectorizers for Redis OM .NET.</Description>
         <Title>Redis OM Vectorizers</Title>
         <Authors>Steve Lorello</Authors>

--- a/src/Redis.OM/Redis.OM.csproj
+++ b/src/Redis.OM/Redis.OM.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>Redis.OM</RootNamespace>
     <Nullable>enable</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <PackageVersion>1.2.0</PackageVersion>
-    <Version>1.2.0</Version>
-    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.2.0</PackageReleaseNotes>
+    <PackageVersion>1.3.0</PackageVersion>
+    <Version>1.3.0</Version>
+    <PackageReleaseNotes>https://github.com/redis/redis-om-dotnet/releases/tag/v1.3.0</PackageReleaseNotes>
     <Description>Object Mapping and More for Redis</Description>
     <Title>Redis OM</Title>
     <Authors>Steve Lorello</Authors>


### PR DESCRIPTION
Revs all four publishable packages from **1.2.0 → 1.3.0** for the next release:

- `Redis.OM`
- `Redis.OM.Vectorizers`
- `Redis.OM.Vectorizers.AllMiniLML6V2`
- `Redis.OM.Vectorizers.Resnet18`

Each project's `PackageVersion`, `Version`, and `PackageReleaseNotes` tag URL are updated. Inter-package dependency versions auto-stamp from `ProjectReference`s at pack time (verified the core packs as `Redis.OM.1.3.0.nupkg`).

### Notable changes since 1.2.0
- RESP3 map parsing for FT.SEARCH/AGGREGATE/INFO (#570 / #571)
- `Match` support for `string` / `IEnumerable<string>` (#551)
- Fix `INDEXMISSING` on non-tag fields (#552)
- Fix `Vector<float[]>` serialization with `FloatVectorizer` (#566 / #569)

### Follow-ups (post-merge)
- The `PackageReleaseNotes` URL points at `releases/tag/v1.3.0`, which 404s until the `v1.3.0` GitHub release/tag is created (same pattern as prior releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only csproj changes with no application logic; main follow-up is creating the matching GitHub release so PackageReleaseNotes URLs resolve.
> 
> **Overview**
> Prepares the **1.3.0** NuGet release by bumping **`PackageVersion`**, **`Version`**, and **`PackageReleaseNotes`** (tag URL) from **1.2.0** to **1.3.0** in all four publishable projects: **`Redis.OM`**, **`Redis.OM.Vectorizers`**, **`Redis.OM.Vectorizers.AllMiniLML6V2`**, and **`Redis.OM.Vectorizers.Resnet18`**.
> 
> There is no runtime or API code in this diff—only release metadata. The release notes link will 404 until the **`v1.3.0`** GitHub tag/release exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5c59777f62c6bfa5811abcb671374443caa956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->