### PR TITLE
Fix infinite FT.SEARCH pagination against offset-ignoring servers (#573)

### DIFF
--- a/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
+++ b/src/Redis.OM/Searching/RedisCollectionEnumerator.cs
@@ -91,14 +91,12 @@ namespace Redis.OM.Searching
                 return true;
             }
 
-            switch (_started)
+            if (ShouldStopPaging())
             {
-                case true when _limited:
-                case true when _records.Documents.Count < _query!.Limit!.Number && _records.DocumentsSkippedCount == 0:
-                    return false;
-                default:
-                    return GetNextChunk();
+                return false;
             }
+
+            return GetNextChunk();
         }
 
         /// <inheritdoc/>
@@ -110,14 +108,12 @@ namespace Redis.OM.Searching
                 return true;
             }
 
-            switch (_started)
+            if (ShouldStopPaging())
             {
-                case true when _limited:
-                case true when _records.Documents.Count < _query!.Limit!.Number && _records.DocumentsSkippedCount == 0:
-                    return false;
-                default:
-                    return await GetNextChunkAsync();
+                return false;
             }
+
+            return await GetNextChunkAsync();
         }
 
         /// <inheritdoc/>
@@ -142,6 +138,67 @@ namespace Redis.OM.Searching
             return expression.Arguments[0].Type.GenericTypeArguments[0];
         }
 
+        /// <summary>
+        /// Determines whether pagination should stop rather than fetch another chunk from the server.
+        /// </summary>
+        /// <remarks>
+        /// Alongside the normal "the server returned a short page" termination, paging also stops once a
+        /// single page has handed back as many documents as the search advertised in total
+        /// (<see cref="SearchResponse{T}.DocumentCount"/>) — at that point the whole result set is in
+        /// hand. On a well-behaved server this only ever coincides with a result set that fits in one
+        /// page (a page can never exceed the requested <c>Number</c>), so it does not change multi-page
+        /// behaviour. It does, however, terminate a server that ignores the <c>LIMIT</c> offset and
+        /// returns an ever-growing <c>[0, offset+Number)</c> window (the RESP3 clustered
+        /// <c>FT.SEARCH</c> coordinator bug fixed in RediSearch#10394), which would otherwise page until
+        /// the server rejects the offset ("LIMIT exceeds maximum of 1000000").
+        /// </remarks>
+        /// <returns>Whether to stop paging.</returns>
+        private bool ShouldStopPaging()
+        {
+            if (!_started)
+            {
+                return false;
+            }
+
+            if (_limited)
+            {
+                return true;
+            }
+
+            // Documents skipped in this chunk (e.g. keys that expired mid-search) mean the real
+            // result set is still being drained, so keep paging.
+            if (_records.DocumentsSkippedCount != 0)
+            {
+                return false;
+            }
+
+            // The server returned a short page, so there is nothing left to fetch.
+            if (_records.Documents.Count < _query!.Limit!.Number)
+            {
+                return true;
+            }
+
+            // A single page returned the whole advertised result set — we already have everything.
+            return _records.Documents.Count >= _records.DocumentCount;
+        }
+
+        /// <summary>
+        /// Determines the index within a freshly fetched chunk at which to begin surfacing documents.
+        /// </summary>
+        /// <remarks>
+        /// A well-behaved server applies the <c>LIMIT</c> offset and returns the window
+        /// <c>[offset, offset+Number)</c>, so iteration starts at the front of the chunk (0). A server
+        /// that ignores the offset returns the prefix <c>[0, offset+Number)</c> instead — detectable
+        /// because it hands back more rows than were requested — so the rows for this page begin at the
+        /// requested offset within the returned set. Starting there skips the prefix already surfaced by
+        /// earlier pages, so each match is surfaced exactly once.
+        /// </remarks>
+        /// <returns>The starting index for the current chunk.</returns>
+        private int StartIndexForChunk()
+        {
+            return _records.Documents.Count > _query!.Limit!.Number ? _query!.Limit!.Offset : 0;
+        }
+
         private bool GetNextChunk()
         {
             if (_started)
@@ -151,7 +208,7 @@ namespace Redis.OM.Searching
 
             var res = _connection.SearchRawResult(_query);
             _records = new SearchResponse<T>(res);
-            _index = 0;
+            _index = StartIndexForChunk();
             _started = true;
             ConcatenateRecords();
             return _index < _records.Documents.Count;
@@ -165,7 +222,7 @@ namespace Redis.OM.Searching
             }
 
             _records = await _connection.SearchAsync<T>(_query).ConfigureAwait(false);
-            _index = 0;
+            _index = StartIndexForChunk();
             _started = true;
             ConcatenateRecords();
             return _index < _records.Documents.Count;

--- a/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
+++ b/test/Redis.OM.Unit.Tests/RediSearchTests/SearchTests.cs
@@ -4413,6 +4413,43 @@ namespace Redis.OM.Unit.Tests.RediSearchTests
         }
 
         [Fact]
+        public async Task EnumerateAllWhenServerIgnoresLimitOffset()
+        {
+            // Regression for #573: some servers (e.g. the RESP3 clustered FT.SEARCH coordinator bug
+            // fixed in RediSearch#10394) ignore the LIMIT offset and return the window [0, offset+count)
+            // on every page. The enumerator must still terminate and surface each match exactly once
+            // rather than paging forever until the server rejects the offset.
+            RedisReply Doc(string id, string name) => new RedisReply[]
+            {
+                new($"Redis.OM.Unit.Tests.RediSearchTests.Person:{id}"),
+                new(new RedisReply[] { "$", $"{{\"Name\":\"{name}\",\"Age\":30,\"Height\":70.0, \"Id\":\"{id}\"}}" }),
+            };
+
+            // Offset is ignored: LIMIT 0 2 returns the first two, LIMIT 2 2 returns all four (0..3).
+            RedisReply firstReply = new RedisReply[] { new(4) }
+                .Concat(((RedisReply[])Doc("00000000000000000000000001", "Steve0")))
+                .Concat(((RedisReply[])Doc("00000000000000000000000002", "Steve1"))).ToArray();
+            RedisReply secondReply = new RedisReply[] { new(4) }
+                .Concat(((RedisReply[])Doc("00000000000000000000000001", "Steve0")))
+                .Concat(((RedisReply[])Doc("00000000000000000000000002", "Steve1")))
+                .Concat(((RedisReply[])Doc("00000000000000000000000003", "Steve2")))
+                .Concat(((RedisReply[])Doc("00000000000000000000000004", "Steve3"))).ToArray();
+
+            _substitute.ClearSubstitute();
+            _substitute.ExecuteAsync("FT.SEARCH", "person-idx", "*", "LIMIT", "0", "2").Returns(firstReply);
+            _substitute.ExecuteAsync("FT.SEARCH", "person-idx", "*", "LIMIT", "2", "2").Returns(secondReply);
+
+            var people = new List<Person>();
+            await foreach (var person in new RedisCollection<Person>(_substitute, 2))
+            {
+                people.Add(person);
+            }
+
+            Assert.Equal(new[] { "Steve0", "Steve1", "Steve2", "Steve3" }, people.Select(p => p.Name));
+            Assert.Equal(4, people.Select(p => p.Id).Distinct().Count());
+        }
+
+        [Fact]
         public void TestBasicQueryCastToIQueryable()
         {
             _substitute.ClearSubstitute();


### PR DESCRIPTION
## What

Fixes #573. Enumerating an `IRedisCollection<T>` (`ToList()`, `foreach`, LINQ materialization) over RESP3 against a **sharded Redis Enterprise / Azure Managed Redis** database paged forever — `LIMIT 0 100`, `LIMIT 100 100`, … — until the server rejected the offset:

```
RedisServerException: LIMIT exceeds maximum of 1000000
Failed on FT.SEARCH <index> * LIMIT 1000000 100
```

## Root cause (server-side)

This is **not** a parser bug. The sharded RediSearch coordinator ignores the `LIMIT` offset over RESP3 and returns the window `[0, offset+count)` on every page instead of `[offset, offset+count)`. Reproduced straight from `redis-cli` on a 3-shard Redis Enterprise 8.2 database:

| Query | RESP2 (correct) | RESP3 (sharded, buggy) |
|---|---|---|
| `LIMIT 100 100` | 100 docs (100–199) | **200 docs (0–199)** |
| `LIMIT 300 100` (offset > total 250) | 0 docs | **250 docs (0–249)** |

Because every page came back at least as large as the requested chunk, the enumerator's "short page" termination never fired and it kept bumping the offset.

Fixed upstream in [RediSearch#10394](https://github.com/RediSearch/RediSearch/pull/10394) (MOD-16767, merged), which also fixes a cluster KNN over-return (`K > count`) affecting **both** RESP2 and RESP3. This PR is the client-side guard for the window between now and that fix reaching Redis Enterprise / Azure Managed Redis releases.

Single-shard Enterprise and OSS `redis-stack` are unaffected, which is why CI never caught it.

## Change

Two defensive measures in `RedisCollectionEnumerator`, both **no-ops against a well-behaved server**:

- **Terminate** paging once a single page has returned as many documents as the search advertised in total (`total_results`). A compliant server can never return more than the requested page size, so this only coincides with a single-page result set there and does not change multi-page behaviour — it never trusts `total_results` to cut short a healthy multi-page (possibly shifting) scan, which is still governed by the existing short-page logic. It *does* terminate the offset-ignoring server, whose growing window eventually contains the whole set.
- **Advance to the requested offset within an over-returned page.** When a page hands back more rows than were requested, the server ignored the offset and returned the `[0, offset+count)` prefix, so iteration begins at array index `offset` (where this page's window actually starts) instead of 0. That skips the prefix already surfaced by earlier pages, so each match is surfaced exactly once — with no per-key set and no per-row counter (O(1), a single index computation per chunk).

## Testing

- New regression test `EnumerateAllWhenServerIgnoresLimitOffset`.
- Existing pagination/expiry tests (`EnumerateAllWhenKeyExpires`, `…AtEnd`, `…ButAllExpired`, `TestPaginationChunkSizes*`) still pass.
- Full net6.0 unit suite: 638 passed, 0 failed, 13 skipped.
- Validated live against the reporter's repro on a sharded Redis Enterprise instance: was an infinite hang → now enumerates all 250 docs correctly, once each, in ~90 ms. (Confirmed the offset-advance is load-bearing: with it disabled the same run returns 550 rows — 250 unique + 300 duplicates.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
